### PR TITLE
added conditional to styling of continue button for Password Screen

### DIFF
--- a/src/reducers/navigation/index.ts
+++ b/src/reducers/navigation/index.ts
@@ -2,7 +2,7 @@ import { NavigationStackAction, NavigationActions } from 'react-navigation'
 import { Routes } from 'src/routes'
 import { routeList } from 'src/routeList'
 
-const action = NavigationActions.navigate({ routeName: routeList.Landing})
+const action = NavigationActions.navigate({ routeName: routeList.Landing })
 const initialState = Routes.router.getStateForAction(action)
 
 export const navigationReducer = (state = initialState, action: NavigationStackAction) => {

--- a/src/ui/registration/components/passwordEntry.tsx
+++ b/src/ui/registration/components/passwordEntry.tsx
@@ -70,6 +70,12 @@ const styles = StyleSheet.create({
     color: JolocomTheme.primaryColorWhite,
     fontSize: JolocomTheme.headerFontSize,
     fontWeight: '100',
+  },
+  buttonTextDisabled: {
+    fontFamily: JolocomTheme.contentFontFamily,
+    color: 'rgba(255,255,255, 0.4)',
+    fontSize: JolocomTheme.headerFontSize,
+    fontWeight: '100',
   }
 })
 
@@ -125,7 +131,7 @@ export const PasswordEntryComponent : React.SFC<Props> = props => {
       </Block>
       <Block flex={ 0.1 }>
         <Button
-          style={{ container: styles.buttonContainer, text: styles.buttonText }}
+          style={ !errorMsg ? { container: styles.buttonContainer, text: styles.buttonText } : { container: styles.buttonContainer, text: styles.buttonTextDisabled }}
           onPress={ props.clickNext }
           raised
           upperCase={ false }

--- a/tests/ui/components/__snapshots__/passwordEntry.test.tsx.snap
+++ b/tests/ui/components/__snapshots__/passwordEntry.test.tsx.snap
@@ -125,7 +125,7 @@ exports[`passwordEntry component matches the snapshot when keyboard is drawn 1`]
             "width": 164,
           },
           "text": Object {
-            "color": "white",
+            "color": "rgba(255,255,255, 0.4)",
             "fontFamily": "TTCommons",
             "fontSize": 22,
             "fontWeight": "100",
@@ -265,7 +265,7 @@ exports[`passwordEntry component matches the snapshot when no input is present 1
             "width": 164,
           },
           "text": Object {
-            "color": "white",
+            "color": "rgba(255,255,255, 0.4)",
             "fontFamily": "TTCommons",
             "fontSize": 22,
             "fontWeight": "100",
@@ -405,7 +405,7 @@ exports[`passwordEntry component matches the snapshot when passwords are not val
             "width": 164,
           },
           "text": Object {
-            "color": "white",
+            "color": "rgba(255,255,255, 0.4)",
             "fontFamily": "TTCommons",
             "fontSize": 22,
             "fontWeight": "100",


### PR DESCRIPTION
## Description

Fixes #1043 

> What does it solve? 
> Were there any particular challenges that you faced and/or things that were not straightforward? 

*NOTE* this is obviously not the optimal way to solve this issue, and is just a PR with the intention to have the button styled correctly for the release. An impending PR to harmonise styles across the app should optimise this solution.

## Checklist
- [x] Keep flags added to the PR up to date
- [x] Make sure the title describes the code well, description should contain `Fixes #number_of_an_issue` and a brief decscription of changes
- [x] Make sure the PR is readable and contains changes only related to a single issue. Otherwise - divide into separate PRs 
- [x] Add a screenshot if there were any UI changes involved 
- [x] Add new tests and make sure all tests are passing
- [x] Make sure all edge cases are taken into account and covered by tests
- [x] Run linter and fix all the errors and warnings
