### PR TITLE
Support for detecting the Other type in the actions

### DIFF
--- a/src/actions/account/categories.ts
+++ b/src/actions/account/categories.ts
@@ -1,9 +1,4 @@
-export enum Categories {
-  Personal,
-  Contact
-}
-
-export const categoryForType: {[key: string] : string[][]} = {
+export const uiCategoryByCredentialType: {[key: string] : string[][]} = {
   'Contact': [
     ['Credential', 'ProofOfEmailCredential'],
     ['Credential', 'ProofOfMobilePhoneNumberCredential'],

--- a/src/actions/account/categories.ts
+++ b/src/actions/account/categories.ts
@@ -1,3 +1,4 @@
+// Why is this in actions TODO
 export const uiCategoryByCredentialType: {[key: string] : string[][]} = {
   'Contact': [
     ['Credential', 'ProofOfEmailCredential'],
@@ -7,3 +8,11 @@ export const uiCategoryByCredentialType: {[key: string] : string[][]} = {
     ['Credential', 'ProofOfNameCredential'],
   ]
 }
+
+export enum Categories {
+  Personal = 'Personal',
+  Contact = 'Contact',
+  Other = 'Other'
+}
+
+export const defaultUiCategories = Object.keys(uiCategoryByCredentialType)

--- a/src/actions/account/index.ts
+++ b/src/actions/account/index.ts
@@ -3,10 +3,8 @@ import { navigationActions, genericActions } from 'src/actions/'
 import { BackendMiddleware } from 'src/backendMiddleware'
 import { routeList } from 'src/routeList'
 import { DecoratedClaims, CategorizedClaims } from 'src/reducers/account'
-import { categoryForType } from 'src/actions/account/categories'
-import { claimsMetadata } from 'jolocom-lib'
 import { VerifiableCredential } from 'jolocom-lib/js/credentials/verifiableCredential'
-import { initialState } from 'src/reducers/account/claims'
+import { getClaimMetadataByCredentialType, getCredentialUiCategory } from '../../lib/util'
 
 export const setDid = (did: string) => {
   return {
@@ -55,38 +53,19 @@ export const openClaimDetails = (claim: DecoratedClaims) => {
 }
 
 export const saveClaim = (claimsItem: DecoratedClaims) => {
-  return async (dispatch: Dispatch<AnyAction>, getState: Function, backendMiddleware : BackendMiddleware) => {
+  return async (dispatch: Dispatch<AnyAction>, getState: Function, backendMiddleware: BackendMiddleware) => {
     const state = getState()
     const { jolocomLib, storageLib, keyChainLib, encryptionLib, ethereumLib } = backendMiddleware
-    let newClaims = {}
-
-    newClaims = state.account.claims.toJS().claims
-
-    // TODO: change the key of claimsMetadata to be the type[1]
-    let claimsMetadataType = ''
-    switch(claimsItem.type[1]) {
-      case 'ProofOfNameCredential':
-        claimsMetadataType = 'name'
-        break
-      case 'ProofOfMobilePhoneNumberCredential':
-        claimsMetadataType = 'mobilePhoneNumber'
-        break
-      case 'ProofOfEmailCredential':
-        claimsMetadataType = 'emailAddress'
-        break
-      default:
-        break
-    }
-
+    const newClaims = state.account.claims.toJS().claims
     const credential = jolocomLib.credentials.createCredential(
-      claimsMetadata[claimsMetadataType],
+      getClaimMetadataByCredentialType(claimsItem.type),
       claimsItem.claims[0].value.trim(),
       state.account.did.toJS().did
     )
 
     const encryptionPass = await keyChainLib.getPassword()
     const currentDid = getState().account.did.get('did')
-    const personaData = await storageLib.get.persona({did: currentDid})
+    const personaData = await storageLib.get.persona({ did: currentDid })
     const { encryptedWif } = personaData[0].controllingKey
     const decryptedWif = encryptionLib.decryptWithPass({
       cipher: encryptedWif,
@@ -97,7 +76,7 @@ export const saveClaim = (claimsItem: DecoratedClaims) => {
     const wallet = jolocomLib.wallet.fromPrivateKey(Buffer.from(privateKey, 'hex'))
     const verifiableCredential = await wallet.signCredential(credential)
 
-    if (claimsItem.claims[0].id && claimsItem.claims[0].id !== '') {
+    if (claimsItem.claims[0].id) {
       await storageLib.delete.verifiableCredential(claimsItem.claims[0].id)
     }
     await storageLib.store.verifiableCredential(verifiableCredential)
@@ -106,6 +85,7 @@ export const saveClaim = (claimsItem: DecoratedClaims) => {
       type: 'SET_CLAIMS_FOR_DID',
       claims: newClaims
     })
+
     dispatch(navigationActions.navigatorReset({
       routeName: routeList.Home
     }))
@@ -135,58 +115,33 @@ export const setClaimsForDid = () => {
   }
 }
 
-const prepareClaimsForState = (claims: VerifiableCredential[]) => {
-  // TODO: Handle the category 'Other' for the claims that don't match any of predefined categories
+const prepareClaimsForState = (credentials: VerifiableCredential[]) => {
   const categorizedClaims = {}
-  const initialClaimsState = initialState
 
-  Object.keys(categoryForType).forEach(category => {
-    const claimsForCategory : DecoratedClaims[] = []
+  const decoratedCredentials = credentials.map(vCred => {
+    const claimData = vCred.getCredentialSection()
+    const claimFieldName = Object.keys(claimData).filter(key => key !== 'id')[0]
 
-    claims.forEach(claim => {
-      const name = claim.getDisplayName()
-      const fieldName = Object.keys(claim.getCredentialSection())[1]
-      const value = claim.getCredentialSection()[fieldName]
-
-      if (typeInCategory(category, claim.getType())) {
-        claimsForCategory.push(
-          { displayName: name,
-            type: claim.getType(),
-            claims: [
-              { id: claim.getId(),
-                name: fieldName,
-                value }
-            ]
-          } as DecoratedClaims
-        )
-      }
-    })
-    if (claimsForCategory.length === 0) {
-      categorizedClaims[category] = initialClaimsState.claims[category]
-    } else {
-      initialClaimsState.claims[category].forEach(claim => {
-        let count = 0
-        claimsForCategory.forEach(dbClaim => {
-          if (areCredTypesEqual(claim.type, dbClaim.type)) {
-            count++
-          }
-        })
-        if (count === 0) {
-          claimsForCategory.push(claim)
-        }
-      })
-      categorizedClaims[category] = claimsForCategory
+    return {
+      displayName: vCred.getDisplayName(),
+      type: vCred.getType(),
+      claims: [{
+        id: claimData.id,
+        name: claimFieldName,
+        value: claimData[claimFieldName]
+      }]
     }
   })
+
+  decoratedCredentials.forEach(decoratedCred => {
+    const uiCategory = getCredentialUiCategory(decoratedCred.type)
+
+    try {
+      categorizedClaims[uiCategory].push(decoratedCred)
+    } catch (err) {
+      categorizedClaims[uiCategory] = [decoratedCred]
+    }
+  })
+
   return categorizedClaims
-}
-
-// TODO: use the method from JolocomLib
-const areCredTypesEqual = (first: string[], second: string[]): boolean => {
-  return first.every((el, index) => el === second[index])
-}
-
-const typeInCategory = (category: string, type: string[]): boolean => {
-  const found = categoryForType[category].find(t => areCredTypesEqual(type, t))
-  return (found && found.length > 0) || false
 }

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,6 +1,6 @@
 import { claimsMetadata } from 'jolocom-lib'
 import { IClaimMetadata } from 'jolocom-lib/js/credentials/credential/types';
-import { uiCategoryByCredentialType } from '../actions/account/categories';
+import { uiCategoryByCredentialType, Categories } from '../actions/account/categories';
 
 export const areCredTypesEqual = (first: string[], second: string[]): boolean => {
   return first.every((el, index) => el === second[index])
@@ -25,5 +25,5 @@ export const getCredentialUiCategory = (type: string[]): string => {
     return credentialFitsDefinition
   })
 
-  return category || 'Other'
+  return category || Categories.Other
 }

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,3 +1,29 @@
+import { claimsMetadata } from 'jolocom-lib'
+import { IClaimMetadata } from 'jolocom-lib/js/credentials/credential/types';
+import { uiCategoryByCredentialType } from '../actions/account/categories';
+
 export const areCredTypesEqual = (first: string[], second: string[]): boolean => {
   return first.every((el, index) => el === second[index])
+}
+
+export const getClaimMetadataByCredentialType = (type: string[]) : IClaimMetadata => {
+  const relevantType = Object.keys(claimsMetadata).find(key => areCredTypesEqual(claimsMetadata[key].type, type))
+
+  if (!relevantType) {
+    throw new Error("Unknown credential type, can't find metadata")
+  }
+
+  return claimsMetadata[relevantType]
+}
+
+export const getCredentialUiCategory = (type: string[]): string => {
+  const uiCategories = Object.keys(uiCategoryByCredentialType)
+
+  const category = uiCategories.find(uiCategory => {
+    const categoryDefinition = uiCategoryByCredentialType[uiCategory]
+    const credentialFitsDefinition = categoryDefinition.some(entry => areCredTypesEqual(entry, type))
+    return credentialFitsDefinition
+  })
+
+  return category || 'Other'
 }

--- a/src/reducers/account/claims.ts
+++ b/src/reducers/account/claims.ts
@@ -3,33 +3,33 @@ import Immutable from 'immutable'
 import { ClaimsState, CategorizedClaims } from 'src/reducers/account'
 
 const categorizedClaims: CategorizedClaims = {
-  'Personal' : [{
-      displayName: 'Name',
-      type: ['Credential', 'ProofOfNameCredential'],
-      claims: [{
-        id: '',
-        name: 'name',
-        value: '',
-      }],
+  'Personal': [{
+    displayName: 'Name',
+    type: ['Credential', 'ProofOfNameCredential'],
+    claims: [{
+      id: '',
+      name: 'name',
+      value: '',
     }],
+  }],
   'Contact': [{
-      displayName: 'E-mail',
-      type: ['Credential', 'ProofOfEmailCredential'],
-      claims: [{
-        id: '',
-        name: 'email',
-        value: ''
-      }],
-    },
-    {
-      displayName: 'Phone',
-      type: ['Credential', 'ProofOfMobilePhoneNumberCredential'],
-      claims: [{
-        id: '',
-        name: 'phone',
-        value: ''
-      }],
-    }]
+    displayName: 'E-mail',
+    type: ['Credential', 'ProofOfEmailCredential'],
+    claims: [{
+      id: '',
+      name: 'email',
+      value: ''
+    }],
+  },
+  {
+    displayName: 'Phone',
+    type: ['Credential', 'ProofOfMobilePhoneNumberCredential'],
+    claims: [{
+      id: '',
+      name: 'phone',
+      value: ''
+    }],
+  }]
 }
 
 export const initialState: ClaimsState = {
@@ -39,7 +39,7 @@ export const initialState: ClaimsState = {
     type: ['', ''],
     claims: []
   },
-  claims: categorizedClaims
+  decoratedCredentials: categorizedClaims
 }
 
 export const claims = (state = Immutable.fromJS(initialState), action: AnyAction): ClaimsState => {
@@ -47,7 +47,7 @@ export const claims = (state = Immutable.fromJS(initialState), action: AnyAction
     case 'SET_LOADING':
       return state.setIn(['loading'], action.loading)
     case 'SET_CLAIMS_FOR_DID':
-      return state.setIn(['claims'], action.claims).setIn(['loading'], false)
+      return state.setIn(['decoratedCredentials'], action.claims).setIn(['loading'], false)
     case 'SET_SELECTED':
       return state.setIn(['selected'], action.selected)
     default:

--- a/src/reducers/account/index.ts
+++ b/src/reducers/account/index.ts
@@ -23,7 +23,7 @@ export interface CategorizedClaims {
 export interface ClaimsState {
   readonly loading: boolean
   readonly selected: DecoratedClaims
-  readonly claims: CategorizedClaims
+  readonly decoratedCredentials: CategorizedClaims
 }
 
 export interface DidState {

--- a/src/ui/home/components/claimCard.tsx
+++ b/src/ui/home/components/claimCard.tsx
@@ -11,6 +11,8 @@ import {
   EmailIcon,
   PhoneIcon
 } from 'src/resources'
+import { getCredentialUiCategory } from '../../../lib/util';
+import { Categories } from '../../../actions/account/categories';
 
 interface Props {
   openClaimDetails: (claim: DecoratedClaims) => void
@@ -63,29 +65,15 @@ const styles = StyleSheet.create({
 })
 
 export const ClaimCard : React.SFC<Props> = ({openClaimDetails, claimItem}) => {
-  const claim = claimItem.claims[0]
-  const { value, name } = claim
-  const displayName = claimItem.displayName
+  const { value, name } = claimItem.claims[0]
+  const { displayName } = claimItem
   const type = claimItem.type[1]
 
   const content = []
 
   // TODO: Extract multi line claim card to a separate component
   if (value && name === 'name' && typeof value === 'string') {
-    const splitName = value.split(',')
-    content.push({
-      value: splitName[0],
-      fieldName: name + 'first',
-      type,
-      label: 'First Name',
-      showIcon: true
-    }, {
-      value: splitName[1],
-      fieldName: name + 'last',
-      type,
-      label: 'Last Name',
-      showIcon: false
-    })
+    content.push(...splitNameCredential(name, value, type))
   } else {
     content.push({value: value || '', fieldName: name, type, label: displayName, showIcon: true})
   }
@@ -112,6 +100,8 @@ export const ClaimCard : React.SFC<Props> = ({openClaimDetails, claimItem}) => {
       textDisplayField
     } = JolocomTheme.textStyles.light
 
+    const isOtherCategory = getCredentialUiCategory(claimItem.type) === Categories.Other
+
     return (
       <ListItem
         key={ fieldName }
@@ -132,16 +122,16 @@ export const ClaimCard : React.SFC<Props> = ({openClaimDetails, claimItem}) => {
         }}
         leftElement={ showIcon ? renderLeftIcon(type) : '' }
         onPress={ claimVal ? undefined : () =>  openClaimDetails(claimItem)}
-        rightElement={ claimVal && showIcon ? renderMoreMenu() : '' }
+        rightElement={ claimVal && showIcon && !isOtherCategory ? renderMoreMenu() : '' }
       />
     )
   }
 
-  return(
-    <View style={ styles.containerField }>
-      { content.map((c, index) => {
+  return (
+    <View style={styles.containerField}>
+      {content.map(c => {
         return renderCard(c.value, c.fieldName, c.type, c.label, c.showIcon)
-      }) }
+      })}
     </View>
   )
 }
@@ -156,4 +146,21 @@ const prepareLabel = (myString : string) : string => {
     })
   }
   return myString[0].toUpperCase() + myString.slice(1)
+}
+
+const splitNameCredential = (fieldName: string, value: string, type: string) => {
+  const splitName = value.split(',')
+  return [{
+    value: splitName[0],
+    fieldName: fieldName + 'first',
+    type,
+    label: 'First Name',
+    showIcon: true
+  }, {
+    value: splitName[1],
+    fieldName: fieldName + 'last',
+    type,
+    label: 'Last Name',
+    showIcon: false
+  }]
 }

--- a/src/ui/home/components/claimOverview.tsx
+++ b/src/ui/home/components/claimOverview.tsx
@@ -16,12 +16,11 @@ interface Props {
   openClaimDetails: (claim: DecoratedClaims) => void
 }
 
-interface State {
-}
+interface State {}
 
 const styles = StyleSheet.create({
   icon: {
-    margin: "20%"
+    margin: '20%'
   },
   iconContainer: {
     height: 55,
@@ -33,7 +32,7 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.8,
     shadowRadius: 2,
-    elevation: 8,
+    elevation: 8
   },
   actionButtonContainer: {
     position: 'absolute',
@@ -63,58 +62,48 @@ const styles = StyleSheet.create({
 
 export class ClaimOverview extends React.Component<Props, State> {
 
-  renderClaimCards = (category: string) : ReactNode => {
+  private renderClaimCards = (category: string): ReactNode => {
     const { openClaimDetails, claims } = this.props
+
     const decoratedClaims: CategorizedClaims = claims.claims
     const categoryClaims: DecoratedClaims[] = decoratedClaims[category] || []
 
-    return categoryClaims.map((claim: DecoratedClaims, index) => {
-        return (
-          <ClaimCard
-            openClaimDetails={ openClaimDetails }
-            claimItem={ claim }
-          />
-        )
+    return categoryClaims.map((claim: DecoratedClaims) => {
+      return <ClaimCard openClaimDetails={openClaimDetails} claimItem={claim} />
     })
   }
 
   render() {
     const { claims } = this.props
     const claimsCategories = Object.keys(claims.claims)
-    const content = 
-    claims.loading ? 
-    <Block><loaders.RippleLoader size={500} strokeWidth={7} color={JolocomTheme.primaryColorPurple} /></Block> : 
-      (claimsCategories.map((category: string) => {
-          return (
-            <View key={category}>
-              <View style={ styles.sectionContainer }>
-                <Text style={ styles.sectionHeader }>{ category.toString() }</Text>
-              </View>
-              { this.renderClaimCards(category) }
+    const content = claims.loading ? (
+      <Block>
+        <loaders.RippleLoader size={500} strokeWidth={7} color={JolocomTheme.primaryColorPurple} />
+      </Block>
+    ) : (
+      claimsCategories.map((category: string) => {
+        return (
+          <View key={category}>
+            <View style={styles.sectionContainer}>
+              <Text style={styles.sectionHeader}>{category.toString()}</Text>
             </View>
-          )
-        })
-      )
+            {this.renderClaimCards(category)}
+          </View>
+        )
+      })
+    )
 
     return (
-      <Container style={ styles.componentContainer }>
-        <ScrollView 
-          style={ styles.scrollComponent } 
-          contentContainerStyle={ claims.loading ? 
-          { flexGrow: 1, justifyContent: 'space-around' } 
-          : {} }>
-            { content }
+      <Container style={styles.componentContainer}>
+        <ScrollView
+          style={styles.scrollComponent}
+          contentContainerStyle={claims.loading ? { flexGrow: 1, justifyContent: 'space-around' } : {}}
+        >
+          {content}
         </ScrollView>
-        <Block style={ styles.actionButtonContainer }>
-          <TouchableOpacity
-            style={ styles.iconContainer }
-            onPress={ this.props.onScannerStart }>
-            <Icon
-              style={ styles.icon }
-              size={ 30 }
-              name='qrcode-scan'
-              color="white"
-            />
+        <Block style={styles.actionButtonContainer}>
+          <TouchableOpacity style={styles.iconContainer} onPress={this.props.onScannerStart}>
+            <Icon style={styles.icon} size={30} name="qrcode-scan" color="white" />
           </TouchableOpacity>
         </Block>
       </Container>

--- a/src/ui/home/containers/claimDetails.tsx
+++ b/src/ui/home/containers/claimDetails.tsx
@@ -27,9 +27,6 @@ export class ClaimDetailsContainer extends React.Component<Props, State> {
     }
   }
 
-  componentWillMount() {
-  }
-
   render() {
       return (
         <ClaimDetailsComponent

--- a/tests/reducers/accounts/__snapshots__/index.test.ts.snap
+++ b/tests/reducers/accounts/__snapshots__/index.test.ts.snap
@@ -12,7 +12,7 @@ Object {
       ],
       "claims": Immutable.List [],
     },
-    "claims": Immutable.Map {
+    "decoratedCredentials": Immutable.Map {
       "Personal": Immutable.List [
         Immutable.Map {
           "displayName": "Name",
@@ -82,7 +82,7 @@ Object {
       ],
       "claims": Immutable.List [],
     },
-    "claims": Immutable.Map {
+    "decoratedCredentials": Immutable.Map {
       "Personal": Immutable.List [
         Immutable.Map {
           "displayName": "Name",

--- a/tests/ui/components/__snapshots__/claimOverview.test.tsx.snap
+++ b/tests/ui/components/__snapshots__/claimOverview.test.tsx.snap
@@ -18,53 +18,6 @@ exports[`ClaimsOverview component matches the snapshot on render 1`] = `
     }
   >
     <Component
-      key="Personal"
-    >
-      <Component
-        style={
-          Object {
-            "marginBottom": 8,
-            "marginLeft": 16,
-            "marginRight": 16,
-            "marginTop": 27,
-          }
-        }
-      >
-        <Text
-          accessible={true}
-          allowFontScaling={true}
-          ellipsizeMode="tail"
-          style={
-            Object {
-              "fontFamily": "TT Commons",
-              "fontSize": 17,
-              "textAlign": "left",
-            }
-          }
-        >
-          Personal
-        </Text>
-      </Component>
-      <ClaimCard
-        claimItem={
-          Object {
-            "claims": Array [
-              Object {
-                "id": "default1",
-                "name": "name",
-                "value": "name",
-              },
-            ],
-            "displayName": "Name",
-            "type": Array [
-              "Credential",
-              "ProofOfNameCredential",
-            ],
-          }
-        }
-      />
-    </Component>
-    <Component
       key="Contact"
     >
       <Component
@@ -124,6 +77,100 @@ exports[`ClaimsOverview component matches the snapshot on render 1`] = `
             "type": Array [
               "Credential",
               "ProofOfMobilePhoneNumberCredential",
+            ],
+          }
+        }
+      />
+    </Component>
+    <Component
+      key="Personal"
+    >
+      <Component
+        style={
+          Object {
+            "marginBottom": 8,
+            "marginLeft": 16,
+            "marginRight": 16,
+            "marginTop": 27,
+          }
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "fontFamily": "TT Commons",
+              "fontSize": 17,
+              "textAlign": "left",
+            }
+          }
+        >
+          Personal
+        </Text>
+      </Component>
+      <ClaimCard
+        claimItem={
+          Object {
+            "claims": Array [
+              Object {
+                "id": "default1",
+                "name": "name",
+                "value": "name",
+              },
+            ],
+            "displayName": "Name",
+            "type": Array [
+              "Credential",
+              "ProofOfNameCredential",
+            ],
+          }
+        }
+      />
+    </Component>
+    <Component
+      key="Other"
+    >
+      <Component
+        style={
+          Object {
+            "marginBottom": 8,
+            "marginLeft": 16,
+            "marginRight": 16,
+            "marginTop": 27,
+          }
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "fontFamily": "TT Commons",
+              "fontSize": 17,
+              "textAlign": "left",
+            }
+          }
+        >
+          Other
+        </Text>
+      </Component>
+      <ClaimCard
+        claimItem={
+          Object {
+            "claims": Array [
+              Object {
+                "id": "default1",
+                "name": "Age",
+                "value": "50",
+              },
+            ],
+            "displayName": "Age",
+            "type": Array [
+              "Credential",
+              "ProofOfAge",
             ],
           }
         }

--- a/tests/ui/components/claimOverview.test.tsx
+++ b/tests/ui/components/claimOverview.test.tsx
@@ -2,11 +2,20 @@ import React from 'react'
 import { ClaimOverview } from 'src/ui/home/components/claimOverview'
 import { shallow } from 'enzyme'
 
-describe('ClaimsOverview component', ()=> {
+describe.only('ClaimsOverview component', ()=> {
   const COMMON_PROPS = {
     claims: {
       loading: false,
-      claims: {
+      decoratedCredentials: {
+        'Other': [{
+            displayName: 'Age',
+            type: ['Credential', 'ProofOfAge'],
+            claims: [{
+              id: 'default1',
+              name: 'Age',
+              value: '50',
+            }],
+        }],
         'Personal' : [{
             displayName: 'Name',
             type: ['Credential', 'ProofOfNameCredential'],


### PR DESCRIPTION
## Description

Fixes #1102 

What does it solve? 
> Allows us to render all non default credentials in the `Other` category.

Were there any particular challenges that you faced and/or things that were not straightforward? 
> Some refactoring was done around the rendering logic, mostly to reduce the amount of code and make things a bit more clear / straight forward

Screenshots (**It is important to realize that this PR does not allow you to edit the custom claims, only render them.**):
![screen shot 2018-09-04 at 11 57 11](https://user-images.githubusercontent.com/11832807/45024786-131c1780-b03a-11e8-8e5c-aaece17608f5.png)

![screen shot 2018-09-04 at 11 57 53](https://user-images.githubusercontent.com/11832807/45024789-17483500-b03a-11e8-9f73-4b12bee84825.png)




## Checklist
- [x] Keep flags added to the PR up to date
- [x] Make sure the title describes the code well, description should contain `Fixes #number_of_an_issue` and a brief decscription of changes
- [x] Make sure the PR is readable and contains changes only related to a single issue. Otherwise - divide into separate PRs 
- [x] Add a screenshot if there were any UI changes involved 
- [x] Add new tests and make sure all tests are passing
- [x] Make sure all edge cases are taken into account and covered by tests
- [x] Run linter and fix all the errors and warnings
