### PR TITLE
Differentiating between self issued and 3rd party issued credentials

### DIFF
--- a/src/actions/sso/index.ts
+++ b/src/actions/sso/index.ts
@@ -33,8 +33,12 @@ export const consumeCredentialRequest = (jwtEncodedCR: string) => {
         const verifications: VerifiableCredential[] = await storageLib.get.vCredentialsByAttributeValue(value)
         const json = verifications.map(v => v.toJSON())
         const validVerifications = CR.applyConstraints(json)
+
+        const { did } = getState().account.did.toJS()
+
         const verificationSummaries = validVerifications.map(verification => ({
           id: verification.id,
+          selfSigned: verification.issuer === did,
           issuer: verification.issuer,
           expires: verification.expires
         }))

--- a/src/reducers/account/index.ts
+++ b/src/reducers/account/index.ts
@@ -34,6 +34,7 @@ export interface LoadingState {
   readonly loading: boolean
 }
 
+// TODO avoid state.account.did.did access patterns
 export interface AccountState {
   did: DidState,
   claims: ClaimsState,

--- a/src/reducers/sso/index.ts
+++ b/src/reducers/sso/index.ts
@@ -8,6 +8,7 @@ export interface StateAttributeSummary {
 export interface StateVerificationSummary {
   id: string
   issuer: string
+  selfSigned: boolean
   expires: string | undefined
 }
 export interface StateTypeSummary {

--- a/src/ui/sso/components/attributeSelectionSection.tsx
+++ b/src/ui/sso/components/attributeSelectionSection.tsx
@@ -73,6 +73,7 @@ export class AttributeSummary extends React.Component<Props, State>{
       <AttributeCard
         key={attribute.value}
         attributeValue={attribute.value}
+        attributeVerifications={attribute.verifications}
         onCheck={this.handleAttributeSelection}
         checked={attribute.value === this.state.selectedAttribute}
       />

--- a/src/ui/sso/components/ssoAttributeCard.tsx
+++ b/src/ui/sso/components/ssoAttributeCard.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { View, Text, StyleSheet } from 'react-native'
 import { IconToggle } from 'react-native-material-ui'
 import { JolocomTheme } from 'src/styles/jolocom-theme'
+import { StateVerificationSummary } from '../../../reducers/sso';
+import Icon from 'react-native-vector-icons/Ionicons'
 
 // TODO Self signed or not
 // TODO Generic group component as opposed to view for flex grouping
@@ -12,9 +14,16 @@ interface AttributeCardProps {
   onCheck: Function
   checked: boolean
   attributeValue: string
+  attributeVerifications: StateVerificationSummary[]
 }
 
 export const AttributeCard : React.SFC<AttributeCardProps> = props => {
+
+  // TODO For now we only look at the first verification on each attribute.
+  const attributeValue = props.attributeValue.replace(',', ' ')
+  const verification = props.attributeVerifications[0]
+  const issuer = verification.selfSigned ? 'Self Signed' : `Issuer: ${verification.issuer.substring(0, 25)}...`
+
   const styles = StyleSheet.create({
     cardContainer: {
       flexDirection: 'row', 
@@ -28,18 +37,27 @@ export const AttributeCard : React.SFC<AttributeCardProps> = props => {
       fontSize: JolocomTheme.headerFontSize,
       color: JolocomTheme.primaryColorBlack,
       fontWeight: '100'
+    },
+    issuerSection: {
+      fontFamily: JolocomTheme.contentFontFamily,
+      fontSize: 17,
+      color: verification.selfSigned ? '#a0a0a3' : '#28a52d',
+      marginTop: '2%',
+      fontWeight: '100'
     }
   })
-  const attributeValue = props.attributeValue.replace(',', ' ')
+
+  const {checked, onCheck} = props
+
   return <View style={styles.cardContainer}>
     <View>
       <Text style={styles.attributeValue}> {attributeValue} </Text>
-      <Text> Self Signed </Text>
+      <Text style={styles.issuerSection}> <Icon name='md-done-all' size={18} /> {issuer} </Text>
     </View>
     <IconToggle 
-      name={props.checked ? 'check-circle': 'fiber-manual-record'} 
-      onPress={() => props.onCheck(props.attributeValue)}
-      color={props.checked ? JolocomTheme.primaryColorPurple : JolocomTheme.disabledButtonBackgroundGrey}
+      name={checked ? 'check-circle': 'fiber-manual-record'} 
+      onPress={() => onCheck(props.attributeValue)}
+      color={checked ? JolocomTheme.primaryColorPurple : JolocomTheme.disabledButtonBackgroundGrey}
     />
   </View>
 }

--- a/src/ui/sso/components/ssoAttributeCard.tsx
+++ b/src/ui/sso/components/ssoAttributeCard.tsx
@@ -22,7 +22,7 @@ export const AttributeCard : React.SFC<AttributeCardProps> = props => {
   // TODO For now we only look at the first verification on each attribute.
   const attributeValue = props.attributeValue.replace(',', ' ')
   const verification = props.attributeVerifications[0]
-  const issuer = verification.selfSigned ? 'Self Signed' : `Issuer: ${verification.issuer.substring(0, 25)}...`
+  const issuer = verification.selfSigned ? 'Self Signed' : `Issuer: ${verification.issuer.substring(0, 20)}...`
 
   const styles = StyleSheet.create({
     cardContainer: {


### PR DESCRIPTION
## Description

Fixes #1104 

What does it solve? 
>Third party issued credentials are rendered differently

Were there any particular challenges that you faced and/or things that were not straightforward? 
> Although this was slightly out of scope of this issue, I took the liberty to give the UI a slight facelift to correspond to Ira's initial designs.

Screenshots:
<img width="561" alt="screen shot 2018-09-04 at 14 48 35" src="https://user-images.githubusercontent.com/11832807/45032697-bc6f0780-b052-11e8-8a66-6d987b4c3afb.png">

<img width="561" alt="screen shot 2018-09-04 at 14 58 13" src="https://user-images.githubusercontent.com/11832807/45032796-f6d8a480-b052-11e8-8166-5a85c2bc7c05.png">



## Checklist
- [x] Keep flags added to the PR up to date
- [x] Make sure the title describes the code well, description should contain `Fixes #number_of_an_issue` and a brief decscription of changes
- [x] Make sure the PR is readable and contains changes only related to a single issue. Otherwise - divide into separate PRs 
- [x] Add a screenshot if there were any UI changes involved 
- [x] Add new tests and make sure all tests are passing
- [x] Make sure all edge cases are taken into account and covered by tests
- [x] Run linter and fix all the errors and warnings
