### PR TITLE
Fixed column name to correspond to cred field.

### DIFF
--- a/src/lib/storage/entities/verifiableCredentialEntity.ts
+++ b/src/lib/storage/entities/verifiableCredentialEntity.ts
@@ -37,7 +37,7 @@ export class VerifiableCredentialEntity {
 
   @Expose()
   @Column({ nullable: true })
-  expiry!: Date
+  expires!: Date
 
   @Expose()
   @ManyToOne(type => PersonaEntity, persona => persona.did)


### PR DESCRIPTION
What does it solve?

Fixes the name of the database column to correspond to the field in the verifiable credential to allow for correct mapping.