### PR TITLE
Bug/#1213 fix button styling

### DIFF
--- a/src/ui/generic/exception.tsx
+++ b/src/ui/generic/exception.tsx
@@ -56,6 +56,7 @@ const styles = StyleSheet.create({
     backgroundColor: JolocomTheme.primaryColorPurple
   },
   buttonText: {
+    paddingVertical: 20,
     fontFamily: JolocomTheme.contentFontFamily,
     color: JolocomTheme.primaryColorWhite,
     fontSize: JolocomTheme.headerFontSize,

--- a/src/ui/structure/buttonSectionBottom.tsx
+++ b/src/ui/structure/buttonSectionBottom.tsx
@@ -20,12 +20,14 @@ export const ButtonSection: React.SFC<Props> = props => {
       backgroundColor: JolocomTheme.primaryColorWhite
     },
     denyButtonText: {
+      paddingVertical: 10,
       fontFamily: JolocomTheme.contentFontFamily,
       fontSize: JolocomTheme.labelFontSize,
       color: JolocomTheme.primaryColorPurple,
       fontWeight: '100'
     },
     confirmButtonText: {
+      paddingVertical: 10,
       fontFamily: JolocomTheme.contentFontFamily,
       fontSize: JolocomTheme.labelFontSize,
       color: props.disabled ? JolocomTheme.disabledButtonTextGrey : JolocomTheme.primaryColorSand,
@@ -35,7 +37,8 @@ export const ButtonSection: React.SFC<Props> = props => {
       width: '40%'
     },
     confirmButton: {
-      width: '40%',
+      paddingHorizontal: 25,
+      borderRadius: 4,
       backgroundColor: props.disabled ? JolocomTheme.disabledButtonBackgroundGrey : JolocomTheme.primaryColorPurple
     }
   })

--- a/tests/ui/generic/__snapshots__/exception.test.tsx.snap
+++ b/tests/ui/generic/__snapshots__/exception.test.tsx.snap
@@ -80,6 +80,7 @@ exports[`Exception screen component Renders correctly 1`] = `
             "fontFamily": "TT Commons",
             "fontSize": 22,
             "fontWeight": "100",
+            "paddingVertical": 20,
           },
         }
       }
@@ -171,6 +172,7 @@ exports[`Exception screen component Renders correctly when no error object is pr
             "fontFamily": "TT Commons",
             "fontSize": 22,
             "fontWeight": "100",
+            "paddingVertical": 20,
           },
         }
       }


### PR DESCRIPTION
Closes #1213.

The buttons on the Share/Receive credentials pages is not up to date with how it appears in the designs in Zeplin but this fix just makes sure the iOS buttons appear normal.