### PR TITLE
Impl/1232/transpile jolocom lib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,10 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.9
-  code_climate:
 node_js:
-  - "8.11.2"
+  - "10.15.1"
 install: 
-  - CC=gcc-4.9 CXX=g++-4.9 yarn install
+  - yarn install
 script: yarn test --runInBand
 after_success:before_script: node_modules/.bin/tslint -c ./tslint.json './src/**/*.ts?(x)'
   - yarn global add codeclimate-test-reporter

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "enzyme-to-json": "^3.3.3",
     "haul": "1.0.0-beta.14",
     "immutable": "^3.8.2",
-    "jest": "^22.4.3",
+    "jest": "^22.4.4",
     "material-colors": "^1.2.5",
     "mockdate": "^2.0.2",
     "prettier": "^1.15.3",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "crypto-js": "^3.1.9-1",
     "ethereumjs-wallet": "^0.6.0",
     "i18n-js": "^3.1.0",
-    "jolocom-lib": "^2.2.9",
+    "jolocom-lib": "^2.3.0",
     "material-colors": "^1.2.5",
     "object.assign": "^4.1.0",
     "react": "16.2.0",

--- a/webpack.haul.js
+++ b/webpack.haul.js
@@ -7,7 +7,7 @@ module.exports = ({ platform }, { module, resolve }) => ({
     rules: [
       {
         test: /\.js/,
-        exclude: /node_modules\/(?!(typeforce|base64url|jsonld|rdf-canonize|tiny-secp256k1|bip32)\/).*/,
+        exclude: /node_modules\/(?!(typeforce|asn1.js|jolocom-lib|base64url|jsonld|rdf-canonize|tiny-secp256k1|bip32)\/).*/,
         loader: 'babel-loader'
       },
       {


### PR DESCRIPTION
Update to Jolocom Lib 2.3.0.
Requires us to use `Node.js v10.x.x` and results in a simpler travis configuration file.