### PR TITLE
Stop QRScanner from scanning multiple times

### DIFF
--- a/src/ui/generic/loadingSpinner.tsx
+++ b/src/ui/generic/loadingSpinner.tsx
@@ -9,6 +9,10 @@ interface Props {}
 const styles = StyleSheet.create({
   loadingContainer: {
     backgroundColor: 'white',
+    padding: 0,
+    position: 'absolute',
+    // to cover things such as the qr code scanner
+    zIndex: 1,
   },
 })
 

--- a/src/ui/generic/qrcodeScanner.tsx
+++ b/src/ui/generic/qrcodeScanner.tsx
@@ -31,23 +31,23 @@ const styles = StyleSheet.create({
 export class QRcodeScanner extends React.Component<Props, State> {
   render() {
     const { loading, onScannerSuccess, onScannerCancel } = this.props
-    if (loading) {
-      return <LoadingSpinner />
-    }
     return (
-      <Container>
-        <QRScanner
-          onRead={(e: QrScanEvent) => onScannerSuccess(e)}
-          topContent={<Text>{I18n.t('You can scan the qr code now!')}</Text>}
-          bottomContent={
-            <Button
-              onPress={onScannerCancel}
-              style={{ text: styles.buttonText }}
-              text={I18n.t('Cancel')}
-            />
-          }
-        />
-      </Container>
+      <React.Fragment>
+        {loading && <LoadingSpinner />}
+        <Container>
+          <QRScanner
+            onRead={(e: QrScanEvent) => onScannerSuccess(e)}
+            topContent={<Text>{I18n.t('You can scan the qr code now!')}</Text>}
+            bottomContent={
+              <Button
+                onPress={onScannerCancel}
+                style={{ text: styles.buttonText }}
+                text={I18n.t('Cancel')}
+              />
+            }
+          />
+        </Container>
+      </React.Fragment>
     )
   }
 }

--- a/tests/ui/components/__snapshots__/qrcodeScanner.test.tsx.snap
+++ b/tests/ui/components/__snapshots__/qrcodeScanner.test.tsx.snap
@@ -1,97 +1,99 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`QRcodeScanner component matches the snapshot with back handler 1`] = `
-<Container>
-  <QRCodeScanner
-    bottomContent={
-      <Button
-        accent={false}
-        disabled={false}
-        icon={null}
-        onLongPress={null}
-        onPress={[Function]}
-        primary={false}
-        raised={false}
-        style={
-          Object {
-            "text": Object {
-              "color": "black",
-            },
+<React.Fragment>
+  <Container>
+    <QRCodeScanner
+      bottomContent={
+        <Button
+          accent={false}
+          disabled={false}
+          icon={null}
+          onLongPress={null}
+          onPress={[Function]}
+          primary={false}
+          raised={false}
+          style={
+            Object {
+              "text": Object {
+                "color": "black",
+              },
+            }
           }
-        }
-        testID={null}
-        text="Cancel"
-        upperCase={true}
-      />
-    }
-    cameraType="back"
-    checkAndroid6Permissions={false}
-    fadeIn={true}
-    notAuthorizedView={
-      <Component
-        style={
-          Object {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
+          testID={null}
+          text="Cancel"
+          upperCase={true}
+        />
+      }
+      cameraType="back"
+      checkAndroid6Permissions={false}
+      fadeIn={true}
+      notAuthorizedView={
+        <Component
+          style={
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "justifyContent": "center",
+            }
           }
-        }
-      >
+        >
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Object {
+                "fontSize": 16,
+                "textAlign": "center",
+              }
+            }
+          >
+            Camera not authorized
+          </Text>
+        </Component>
+      }
+      onRead={[Function]}
+      pendingAuthorizationView={
+        <Component
+          style={
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Object {
+                "fontSize": 16,
+                "textAlign": "center",
+              }
+            }
+          >
+            ...
+          </Text>
+        </Component>
+      }
+      permissionDialogMessage="Need camera permission"
+      permissionDialogTitle="Info"
+      reactivate={false}
+      reactivateTimeout={0}
+      showMarker={false}
+      topContent={
         <Text
           accessible={true}
           allowFontScaling={true}
           ellipsizeMode="tail"
-          style={
-            Object {
-              "fontSize": 16,
-              "textAlign": "center",
-            }
-          }
         >
-          Camera not authorized
+          You can scan the qr code now!
         </Text>
-      </Component>
-    }
-    onRead={[Function]}
-    pendingAuthorizationView={
-      <Component
-        style={
-          Object {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-          }
-        }
-      >
-        <Text
-          accessible={true}
-          allowFontScaling={true}
-          ellipsizeMode="tail"
-          style={
-            Object {
-              "fontSize": 16,
-              "textAlign": "center",
-            }
-          }
-        >
-          ...
-        </Text>
-      </Component>
-    }
-    permissionDialogMessage="Need camera permission"
-    permissionDialogTitle="Info"
-    reactivate={false}
-    reactivateTimeout={0}
-    showMarker={false}
-    topContent={
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-      >
-        You can scan the qr code now!
-      </Text>
-    }
-  />
-</Container>
+      }
+    />
+  </Container>
+</React.Fragment>
 `;


### PR DESCRIPTION
Previous logic of rendering QRScanner conditionally on loading state
from store meant that it would unmount/remount and potentially scan
multiple times and cause multiple parsing events. QRScanner is now
always rendered, even when loading state is true.