### PR TITLE
1273/fix typing issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@types/node": "^10.0.6",
     "@types/react": "^16.0.40",
     "@types/react-native": "^0.55.7",
-    "@types/react-native-material-ui": "^1.19.2",
+    "@types/react-native-material-ui": "^1.31.1",
     "@types/react-native-snap-carousel": "^3.6.0",
     "@types/react-native-sqlite-storage": "^3.3.0",
     "@types/react-native-vector-icons": "^4.6.0",

--- a/src/ui/home/components/claimDetails.tsx
+++ b/src/ui/home/components/claimDetails.tsx
@@ -5,6 +5,8 @@ import {
   Keyboard,
   EmitterSubscription,
   Dimensions,
+  ViewStyle,
+  TextStyle,
 } from 'react-native'
 import { JolocomTheme } from 'src/styles/jolocom-theme'
 import { DecoratedClaims } from 'src/reducers/account/'
@@ -15,7 +17,16 @@ import I18n from 'src/locales/i18n'
 
 const viewHeight: number = Dimensions.get('window').height
 
-const styles = StyleSheet.create({
+interface ClaimDetailsStyles {
+  blockSpace: ViewStyle
+  blockSpaceLast: ViewStyle
+  buttonContainer: ViewStyle
+  buttonContainerDisabled: ViewStyle
+  buttonText: TextStyle
+  buttonTextDisabled: TextStyle
+}
+
+const styles = StyleSheet.create<ClaimDetailsStyles>({
   blockSpace: {
     marginTop: viewHeight / 40,
     marginBottom: viewHeight / 40,

--- a/src/ui/structure/block.tsx
+++ b/src/ui/structure/block.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { View, StyleSheet, ViewStyle } from 'react-native'
+import { View, StyleSheet, ViewStyle, StyleProp } from 'react-native'
 import { ReactNode } from 'react'
 
 const styles = StyleSheet.create({
@@ -20,7 +20,7 @@ interface Props {
   children: ReactNode
   flex?: number
   debug?: boolean
-  style?: ViewStyle | ViewStyle[]
+  style?: StyleProp<ViewStyle>
   onTouch?: () => void
 }
 

--- a/src/ui/structure/centeredText.tsx
+++ b/src/ui/structure/centeredText.tsx
@@ -10,7 +10,6 @@ const styles = StyleSheet.create<CenteredTextStyles>({
     width: '100%',
     textAlign: 'center',
     fontSize: 16,
-    borderBottomColor: 'green',
   },
 })
 

--- a/src/ui/structure/centeredText.tsx
+++ b/src/ui/structure/centeredText.tsx
@@ -1,11 +1,16 @@
 import React from 'react'
 import { StyleSheet, TextStyle, Text, StyleProp } from 'react-native'
 
-const styles = StyleSheet.create({
+interface CenteredTextStyles {
+  text: TextStyle
+}
+
+const styles = StyleSheet.create<CenteredTextStyles>({
   text: {
     width: '100%',
-    textAlign: 'center' as 'center',
+    textAlign: 'center',
     fontSize: 16,
+    borderBottomColor: 'green',
   },
 })
 

--- a/src/ui/structure/centeredText.tsx
+++ b/src/ui/structure/centeredText.tsx
@@ -1,17 +1,17 @@
 import React from 'react'
-import { StyleSheet, TextStyle, Text } from 'react-native'
+import { StyleSheet, TextStyle, Text, StyleProp } from 'react-native'
 
 const styles = StyleSheet.create({
   text: {
     width: '100%',
-    textAlign: 'center',
+    textAlign: 'center' as 'center',
     fontSize: 16,
   },
 })
 
 interface Props {
   msg: string
-  style?: TextStyle
+  style?: StyleProp<TextStyle>
 }
 
 export const CenteredText: React.SFC<Props> = props => (

--- a/src/ui/structure/container.tsx
+++ b/src/ui/structure/container.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { View, StyleSheet, ViewStyle, RegisteredStyle } from 'react-native'
+import { View, StyleSheet, ViewStyle, StyleProp } from 'react-native'
 import { ReactNode } from 'react'
 import { JolocomTheme } from 'src/styles/jolocom-theme'
 
@@ -18,7 +18,7 @@ const styles = StyleSheet.create({
 
 interface Props {
   children: ReactNode
-  style?: ViewStyle | RegisteredStyle<ViewStyle>
+  style?: StyleProp<ViewStyle>
 }
 
 export const Container: React.SFC<Props> = props => (

--- a/yarn.lock
+++ b/yarn.lock
@@ -507,9 +507,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.4.tgz#1c586b991457cbb58fef51bc4e0cfcfa347714b5"
   integrity sha512-DT25xX/YgyPKiHFOpNuANIQIVvYEwCWXgK2jYYwqgaMrYE6+tq+DtmMwlD3drl6DJbUwtlIDnn0d7tIn/EbXBg==
 
-"@types/react-native-material-ui@^1.19.2":
-  version "1.19.3"
-  resolved "https://registry.yarnpkg.com/@types/react-native-material-ui/-/react-native-material-ui-1.19.3.tgz#9d4c732fa858179a5c3b57e9f7519e13e6698f05"
+"@types/react-native-material-ui@^1.31.1":
+  version "1.31.1"
+  resolved "https://registry.yarnpkg.com/@types/react-native-material-ui/-/react-native-material-ui-1.31.1.tgz#84ab5674038956103b3858d2d5877c47a69ed8d0"
+  integrity sha512-fsAH8s2K+dRUztMUTQqFRv22wz3PvB0nW6QS2WWVSZSU+H6dxlkqt4iCDXAB3HHSXl5bIVSofQwIEehaq37fVg==
   dependencies:
     "@types/react" "*"
     "@types/react-native" "*"


### PR DESCRIPTION
Closes #1273.

Currently this fixes CenteredText, Block and Container.

The last problems we have are all to do with the Button component from [react-native-material-ui](https://github.com/xotahal/react-native-material-ui), which expects TextStyle | undefined for the text part and ViewStyle | undefined for the container part. Creating these using Stylesheet.create actually creates RegisteredStyle<ViewStyle> and RegisteredStyle<TextStyle> rather than ViewStyle/TextStyle, and leads to these typing errors.

We could:

- override the typings of the Button component (is this even possible?)
- typecast the styles as we pass them into Button
- create plain objects to pass as styles for Button