### PR TITLE
Bumped versions to 1.3.1

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -102,8 +102,8 @@ android {
         applicationId "com.jolocomwallet"
         minSdkVersion 16
         targetSdkVersion 26
-        versionCode 12
-        versionName "1.3.0"
+        versionCode 13
+        versionName "1.3.1"
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }

--- a/ios/smartwallet/Info.plist
+++ b/ios/smartwallet/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.0</string>
+	<string>1.3.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jolocomwallet",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "devDependencies": {
     "@types/enzyme": "^3.1.9",


### PR DESCRIPTION
Bump according to #1278 
> ### Updates
> * Addressed Typescript errors when bundling the Application #1274 
> * Initial setup for abstracting the registry related functionality #1276
> * Updated the used version of the Jolocom-Lib to [v2.4.2](https://github.com/jolocom/jolocom-lib/releases/tag/v2.4.2)