### PR TITLE
Correctly checking if requested input is not populated on credential offer

### DIFF
--- a/src/actions/sso/credentialOfferRequest.ts
+++ b/src/actions/sso/credentialOfferRequest.ts
@@ -3,7 +3,7 @@ import { AppError, ErrorCode } from '../../lib/errors'
 import { showErrorScreen } from '../generic'
 import { CredentialOfferRequest } from 'jolocom-lib/js/interactionTokens/credentialOfferRequest'
 import { receiveExternalCredential } from './index'
-import { all, compose, isEmpty, isNil, map, mergeRight, omit } from 'ramda'
+import { all, compose, isEmpty, isNil, map, mergeRight, omit, either } from 'ramda'
 import { httpAgent } from '../../lib/http'
 import { JolocomLib } from 'jolocom-lib'
 import { CredentialsReceive } from 'jolocom-lib/js/interactionTokens/credentialsReceive'
@@ -90,6 +90,6 @@ export const consumeCredentialOfferRequest = (
 
 const areRequirementsEmpty = (interactionToken: CredentialOfferRequest) =>
   compose(
-    all(isNil || isEmpty),
+    all(either(isNil, isEmpty)),
     map(interactionToken.getRequestedInputForType.bind(interactionToken)),
   )(interactionToken.offeredTypes)


### PR DESCRIPTION
We currently don't support requesting data as part of a credential offer. The wallet should render an error  screen in case the `requestedInput` field is populated. 

This was implemented incorrectly, and this PR fixes the validation logic.