### PR TITLE
registration: don't bork when registration fails

### DIFF
--- a/src/actions/registration/index.ts
+++ b/src/actions/registration/index.ts
@@ -60,7 +60,6 @@ export const createIdentity = (encodedEntropy: string): ThunkAction => async (
     pass: password,
   })
   const entropyData = { encryptedEntropy: encEntropy, timestamp: Date.now() }
-  await storageLib.store.encryptedSeed(entropyData)
   const userVault = JolocomLib.KeyProvider.fromSeed(
     Buffer.from(encodedEntropy, 'hex'),
     password,
@@ -83,10 +82,12 @@ export const createIdentity = (encodedEntropy: string): ThunkAction => async (
     controllingKeyPath: JolocomLib.KeyTypes.jolocomIdentityKey,
   }
 
-  await storageLib.store.persona(personaData)
   dispatch(setDid(identityWallet.identity.did))
   dispatch(setLoadingMsg(loading.loadingStages[3]))
   await backendMiddleware.setIdentityWallet(userVault, password)
+
+  await storageLib.store.encryptedSeed(entropyData)
+  await storageLib.store.persona(personaData)
 
   return dispatch(
     navigationActions.navigatorReset({

--- a/src/ui/registration/containers/entropy.tsx
+++ b/src/ui/registration/containers/entropy.tsx
@@ -11,6 +11,8 @@ import { generateSecureRandomBytes } from 'src/lib/util'
 import { withErrorHandling } from 'src/actions/modifiers'
 import { showErrorScreen } from 'src/actions/generic'
 import { ThunkDispatch } from 'src/store'
+import { AppError, ErrorCode } from '../../../lib/errors'
+import { routeList } from 'src/routeList'
 
 interface Props
   extends ReturnType<typeof mapDispatchToProps>,
@@ -95,9 +97,11 @@ const mapStateToProps = (state: RootState) => ({})
 const mapDispatchToProps = (dispatch: ThunkDispatch) => ({
   submit: (encodedEntropy: string) =>
     dispatch(
-      withErrorHandling(showErrorScreen)(
-        registrationActions.submitEntropy(encodedEntropy),
-      ),
+      withErrorHandling(
+        showErrorScreen,
+        (err: Error) =>
+          new AppError(ErrorCode.RegistrationFailed, err, routeList.Landing)
+      )(registrationActions.submitEntropy(encodedEntropy)),
     ),
 })
 


### PR DESCRIPTION
Fixes #1238

Persist the seed data and persona data only after full successful anchoring of the identity