### PR TITLE
Fix typeorm multiple active connections issue

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
 
         <activity
           android:name=".MainActivity"
-          android:launchMode="singleTop"
+          android:launchMode="singleTask"
           android:label="@string/app_name"
           android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
           android:windowSoftInputMode="adjustResize"

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,16 @@
+/**
+ * Object.setPrototypeOf polyfill because typeorm (and possibly others) use it
+ */
+
+// @ts-ignore
+if (!Object.setPrototypeOf) {
+  // @ts-ignore
+  Object.setPrototypeOf = function(obj, proto) {
+    obj.__proto__ = proto
+    return obj
+  }
+}
+
 import { AppRegistry } from 'react-native'
 
 import App from 'src/App'


### PR DESCRIPTION
- polyfill for `Object.setPrototypeOf` to actually get the error
- switch android MainActivity to `singleTask` mode so that nothing starts multiple instances of the app (for example through deep links)