### PR TITLE
Restore iOS deep link

### DIFF
--- a/ios/JolocomWallet/AppDelegate.m
+++ b/ios/JolocomWallet/AppDelegate.m
@@ -10,6 +10,7 @@
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTRootView.h>
+#import <React/RCTLinkingManager.h>
 
 @implementation AppDelegate
 
@@ -28,6 +29,13 @@
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
   return YES;
+}
+
+- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url
+  sourceApplication:(NSString *)sourceApplication annotation:(id)annotation
+{
+  return [RCTLinkingManager application:application openURL:url
+                      sourceApplication:sourceApplication annotation:annotation];
 }
 
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge


### PR DESCRIPTION
Deep link functionality on iOS on the upgrade React Native branch didn't work properly. A deep link would only open the app if the app was not already running.

The lines added in this pull request were added to AppDelegate.m in develop a while ago but not ported over to the new project.