### PR TITLE
Add debug mixin style

### DIFF
--- a/src/styles/presets.ts
+++ b/src/styles/presets.ts
@@ -6,3 +6,8 @@ export const landingBackground = {
 export const landingBackgroundImage = {
   resizeMode: 'cover',
 }
+
+export const debug = {
+  borderWidth: 1,
+  borderColor: 'rgba(242, 38, 19, 0.7)',
+}


### PR DESCRIPTION
Previously we had a debug prop that would cause a debug style on Block
and other structure components. I have used a sort of debug style during
development of the SmartWallet and believe that it is useful. Having a
debug mixin that is already defined and that can just be imported is handy.