### PR TITLE
Skipping empty fields when rendering consent screen

### DIFF
--- a/src/ui/sso/components/checkboxCredential.tsx
+++ b/src/ui/sso/components/checkboxCredential.tsx
@@ -7,6 +7,7 @@ import { StateTypeSummary, StateVerificationSummary } from 'src/reducers/sso'
 import I18n from 'src/locales/i18n'
 import strings from 'src/locales/strings'
 import { IconToggle } from 'react-native-material-ui'
+import { reject, isEmpty } from 'ramda'
 
 const styles = StyleSheet.create({
   container: {
@@ -57,7 +58,7 @@ export const CheckboxCredential: React.FC<CheckboxCredentialProps> = props => {
   return (
     <View style={styles.container}>
       <View style={styles.claimArea}>
-        {values.map(value => (
+        {reject(isEmpty, values).map(value => (
           <Text style={styles.claimText}>{value}</Text>
         ))}
         <View style={styles.issuerStatusContainer}>

--- a/src/utils/filterDocuments.ts
+++ b/src/utils/filterDocuments.ts
@@ -7,10 +7,14 @@ const DOC_TYPES = [
   'DrivingLicense',
   'Certificate',
   'EventTicket',
+  'Proof Of Driving License Credential',
 ]
 
 const isIncludedIn = <T>(list: T[]) => (element: T) => includes(element, list)
 
+/** @TODO Housekeeping - We should compare against DOC_TYPES using the `type`
+ *    of a credential instead of the `credentialType` (which is formatted for render)
+ */
 const isDocument = ({ credentialType, renderInfo = {} }: DecoratedClaims) =>
   compose(
     // @ts-ignore


### PR DESCRIPTION
Closes #1444 

The empty elements from the credential are now omited, and the screen currently renders as follows:
![image](https://user-images.githubusercontent.com/11832807/64475132-d5872880-d17e-11e9-9f80-d74675b3ce46.png)
