### PR TITLE
Bump version numbers to 1.7.0

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -107,8 +107,8 @@ android {
         applicationId "com.jolocomwallet"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 17
-        versionName "1.6.0"
+        versionCode 18
+        versionName "1.7.0"
         vectorDrawables.useSupportLibrary = true
         missingDimensionStrategy 'react-native-camera', 'general'
     }

--- a/ios/JolocomWallet/Base.lproj/Info.plist
+++ b/ios/JolocomWallet/Base.lproj/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>1.7.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jolocomwallet",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "private": true,
   "devDependencies": {
     "@babel/cli": "^7.4.4",


### PR DESCRIPTION
Bumped versions

> ### Updates
>
>* Upgraded to React Native 0.59 #1380
>* The seed phrase screen is no longer part of the registration flow, and is now accessible through the settings screen #1418
>* Added UI and functionality for recovering the identity based on 12-word seed phrases #1266 
>* Updated the landing page screen #1430 
>* Updated the entropy collection screen #1428 
>* The wallet no longer requires internet connection on startup #1327
>* Added support for custom database migrations #1412
>* Various minor UI / UX improvements #1449, #1450, #1445 
>* Updated README #1389
>* Refactored styling structure #1386
>  - Removed JolocomTheme #1432
>  - Add debug mixin style for development #1440
