### PR TITLE
Hotfix/android bump version code

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -107,7 +107,7 @@ android {
         applicationId "com.jolocomwallet"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 18
+        versionCode 19
         versionName "1.7.0"
         vectorDrawables.useSupportLibrary = true
         missingDimensionStrategy 'react-native-camera', 'general'

--- a/ios/JolocomWallet/Base.lproj/Info.plist
+++ b/ios/JolocomWallet/Base.lproj/Info.plist
@@ -34,7 +34,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSApplicationCategoryType</key>
 	<string/>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
We have to bump both build numbers again because the currently incremented ones were used to publish the internal beta apps.