### PR TITLE
Housekeeping/simplify group attributes by credential

### DIFF
--- a/src/lib/storage/storage.ts
+++ b/src/lib/storage/storage.ts
@@ -158,7 +158,6 @@ export class Storage {
       .where('verifiableCredential.type = :type', { type })
       .getMany()
 
-    // Multiple credentials of the same type, i.e. ['Credential', 'ProofOfNameCredential']
     const results = groupAttributesByCredentialId(localAttributes).map(
       entry => ({
         verification: entry.verifiableCredential.id,

--- a/src/lib/storage/storage.ts
+++ b/src/lib/storage/storage.ts
@@ -20,6 +20,7 @@ import {
 } from 'jolocom-lib/js/interactionTokens/interactionTokens.types'
 import { IdentitySummary } from '../../actions/sso/types'
 import { DidDocument } from 'jolocom-lib/js/identity/didDocument/didDocument'
+import { groupAttributesByCredentialId } from './utils'
 
 interface PersonaAttributes {
   did: string
@@ -29,12 +30,6 @@ interface PersonaAttributes {
 interface EncryptedSeedAttributes {
   encryptedEntropy: string
   timestamp: number
-}
-
-interface ModifiedCredentialEntity {
-  propertyName: string
-  propertyValue: string[]
-  verifiableCredential: VerifiableCredentialEntity
 }
 
 export class Storage {
@@ -163,7 +158,8 @@ export class Storage {
       .where('verifiableCredential.type = :type', { type })
       .getMany()
 
-    const results = this.groupAttributesByCredentialId(localAttributes).map(
+    // Multiple credentials of the same type, i.e. ['Credential', 'ProofOfNameCredential']
+    const results = groupAttributesByCredentialId(localAttributes).map(
       entry => ({
         verification: entry.verifiableCredential.id,
         values: entry.propertyValue,
@@ -172,44 +168,6 @@ export class Storage {
     )
 
     return { type, results }
-  }
-
-  // TODO rework
-  private groupAttributesByCredentialId(
-    attributes: CredentialEntity[],
-  ): ModifiedCredentialEntity[] {
-    // Convert values to arrays for easier concatination later
-    const modifiedAttributes = attributes.map(attr => ({
-      ...attr,
-      propertyValue: [attr.propertyValue],
-    }))
-
-    // Helper function
-    const findByCredId = (
-      arrToSearch: ModifiedCredentialEntity[],
-      value: ModifiedCredentialEntity,
-    ) =>
-      arrToSearch.findIndex(
-        entry =>
-          entry.verifiableCredential.id === value.verifiableCredential.id,
-      )
-
-    return modifiedAttributes.reduce(
-      (acc: ModifiedCredentialEntity[], curr: ModifiedCredentialEntity) => {
-        const matchingIndex = findByCredId(acc, curr)
-
-        if (matchingIndex >= 0) {
-          acc[matchingIndex].propertyValue = [
-            ...acc[matchingIndex].propertyValue,
-            ...curr.propertyValue,
-          ]
-          return acc
-        } else {
-          return [...acc, curr]
-        }
-      },
-      [],
-    )
   }
 
   private async getVCredentialsForAttribute(

--- a/src/lib/storage/utils.ts
+++ b/src/lib/storage/utils.ts
@@ -15,14 +15,14 @@ export const groupAttributesByCredentialId = (
   /** @dev We get a number of credential entities. Each contains one claim. We first
    * group all entities part of the same credential together (i.e. given name, family name)
    */
-  const groupeByCredential = Object.values(
+  const groupedByCredential = Object.values(
     groupBy(
       (credential: CredentialEntity) => credential.verifiableCredential.id,
       credentials,
     ),
   )
 
-  return groupeByCredential.map(credentials => {
+  return groupedByCredential.map(credentials => {
     return {
       ...credentials[0],
       propertyValue: credentials.map(cred => cred.propertyValue),

--- a/src/lib/storage/utils.ts
+++ b/src/lib/storage/utils.ts
@@ -1,0 +1,50 @@
+// TODO rework
+// Multiple credentials of the same type, i.e. ['Credential', 'ProofOfNameCredential']
+import {
+  CredentialEntity,
+  VerifiableCredentialEntity,
+} from './entities'
+
+interface ModifiedCredentialEntity {
+  propertyName: string
+  propertyValue: string[]
+  verifiableCredential: VerifiableCredentialEntity
+}
+
+export const groupAttributesByCredentialId = (
+  credentials: CredentialEntity[],
+): ModifiedCredentialEntity[] => {
+  // Convert values to arrays for easier concatination later
+  const modifiedAttributes = credentials.map(credential => ({
+    ...credential,
+    propertyValue: [credential.propertyValue], // "eugeniu@jolocom.com" -> ["eugeniu@jolocom.com"]
+  }))
+
+  // Helper function
+  const findByCredId = (
+    arrToSearch: ModifiedCredentialEntity[],
+    value: ModifiedCredentialEntity,
+  ) =>
+    arrToSearch.findIndex(
+      entry => entry.verifiableCredential.id === value.verifiableCredential.id,
+    )
+
+  debugger
+  return modifiedAttributes.reduce(
+    (acc: ModifiedCredentialEntity[], curr: ModifiedCredentialEntity) => {
+      const matchingIndex = findByCredId(acc, curr)
+
+      // This seems to be a hack, uniting individual claims from the credential back together
+      if (matchingIndex >= 0) {
+        acc[matchingIndex].propertyValue = [
+          ...acc[matchingIndex].propertyValue,
+          ...curr.propertyValue,
+        ]
+        return acc
+      } else {
+        return [...acc, curr]
+      }
+    },
+    [],
+  )
+}

--- a/src/lib/storage/utils.ts
+++ b/src/lib/storage/utils.ts
@@ -1,11 +1,5 @@
 import { groupBy } from 'ramda'
-import { CredentialEntity, VerifiableCredentialEntity } from './entities'
-
-interface ModifiedCredentialEntity {
-  propertyName: string
-  propertyValue: string[]
-  verifiableCredential: VerifiableCredentialEntity
-}
+import { CredentialEntity } from './entities'
 
 /**
  * Given an array of Credential Entities, will attempt to group them by
@@ -17,7 +11,7 @@ interface ModifiedCredentialEntity {
 
 export const groupAttributesByCredentialId = (
   credentials: CredentialEntity[],
-): ModifiedCredentialEntity[] => {
+) => {
   /** @dev We get a number of credential entities. Each contains one claim. We first
    * group all entities part of the same credential together (i.e. given name, family name)
    */
@@ -28,7 +22,7 @@ export const groupAttributesByCredentialId = (
     ),
   )
 
-  return groupeByCredential.map<ModifiedCredentialEntity>(credentials => {
+  return groupeByCredential.map(credentials => {
     return {
       ...credentials[0],
       propertyValue: credentials.map(cred => cred.propertyValue),

--- a/tests/lib/storage.test.ts
+++ b/tests/lib/storage.test.ts
@@ -1,9 +1,15 @@
+import { groupAttributesByCredentialId } from '../../src/lib/storage/utils'
+import {
+  CredentialEntity,
+  VerifiableCredentialEntity,
+} from '../../src/lib/storage/entities'
+
 describe('lib/storage', () => {
   jest.unmock('src/lib/storage/storage')
   jest.mock('src/lib/storage/entities', () => ({}))
   jest.mock('typeorm/browser', () => {
     return {
-      createConnection: jest.fn().mockResolvedValue({})
+      createConnection: jest.fn().mockResolvedValue({}),
     }
   })
 
@@ -12,7 +18,8 @@ describe('lib/storage', () => {
     const config = {}
 
     describe('initConnection', () => {
-      const createConnection: jest.Mock = require('typeorm/browser').createConnection
+      const createConnection: jest.Mock = require('typeorm/browser')
+        .createConnection
 
       it('should create only one connection if called multiple times synchronously', async () => {
         createConnection.mockClear()
@@ -37,11 +44,56 @@ describe('lib/storage', () => {
           // this should not attempt to createConnection, but rather return the
           // previous promise, which is mocked to be rejected
           await storage.initConnection()
-        } catch(err) {
+        } catch (err) {
           // this should call createConnection again
           await storage.initConnection()
         }
         expect(createConnection).toHaveBeenCalledTimes(2)
+      })
+    })
+    describe('Helper functions', () => {
+      it('Should correctly group credentials by credential id', () => {
+        const mockCredential: CredentialEntity[] = [
+          {
+            propertyName: 'email',
+            propertyValue: 'test@example.com',
+            id: 5,
+            verifiableCredential: {
+              id: '01',
+            } as VerifiableCredentialEntity,
+          },
+          {
+            id: 6,
+            propertyName: 'givenName',
+            propertyValue: 'Mark',
+            verifiableCredential: {
+              id: '02',
+            } as VerifiableCredentialEntity,
+          },
+          {
+            id: 7,
+            propertyName: 'familyName',
+            propertyValue: 'Mustermann',
+            verifiableCredential: {
+              id: '02',
+            } as VerifiableCredentialEntity,
+          },
+        ]
+
+        expect(groupAttributesByCredentialId(mockCredential)).toStrictEqual([
+          {
+            propertyName: 'email',
+            propertyValue: ['test@example.com'],
+            id: 5,
+            verifiableCredential: { id: '01' },
+          },
+          {
+            id: 6,
+            propertyName: 'givenName',
+            propertyValue: ['Mark', 'Mustermann'],
+            verifiableCredential: { id: '02' },
+          },
+        ])
       })
     })
   })

--- a/tests/lib/storage.test.ts
+++ b/tests/lib/storage.test.ts
@@ -53,45 +53,44 @@ describe('lib/storage', () => {
     })
     describe('Helper functions', () => {
       it('Should correctly group credentials by credential id', () => {
+        const credentialEnittyTemplate = {
+          propertyName: 'givenName',
+          propertyValue: 'Mark',
+          id: 0,
+          verifiableCredential: {
+            id: '00',
+          } as VerifiableCredentialEntity,
+        }
+
         const mockCredential: CredentialEntity[] = [
+          credentialEnittyTemplate,
           {
+            ...credentialEnittyTemplate,
+            propertyName: 'familyName',
+            propertyValue: 'Musterman',
+          },
+          {
+            ...credentialEnittyTemplate,
             propertyName: 'email',
             propertyValue: 'test@example.com',
-            id: 5,
             verifiableCredential: {
               id: '01',
-            } as VerifiableCredentialEntity,
-          },
-          {
-            id: 6,
-            propertyName: 'givenName',
-            propertyValue: 'Mark',
-            verifiableCredential: {
-              id: '02',
-            } as VerifiableCredentialEntity,
-          },
-          {
-            id: 7,
-            propertyName: 'familyName',
-            propertyValue: 'Mustermann',
-            verifiableCredential: {
-              id: '02',
             } as VerifiableCredentialEntity,
           },
         ]
 
         expect(groupAttributesByCredentialId(mockCredential)).toStrictEqual([
           {
-            propertyName: 'email',
-            propertyValue: ['test@example.com'],
-            id: 5,
-            verifiableCredential: { id: '01' },
+            id: 0,
+            propertyName: 'givenName',
+            propertyValue: ['Mark', 'Musterman'],
+            verifiableCredential: { id: '00' },
           },
           {
-            id: 6,
-            propertyName: 'givenName',
-            propertyValue: ['Mark', 'Mustermann'],
-            verifiableCredential: { id: '02' },
+            propertyName: 'email',
+            propertyValue: ['test@example.com'],
+            id: 0,
+            verifiableCredential: { id: '01' },
           },
         ])
       })

--- a/tests/lib/storage.test.ts
+++ b/tests/lib/storage.test.ts
@@ -53,7 +53,7 @@ describe('lib/storage', () => {
     })
     describe('Helper functions', () => {
       it('Should correctly group credentials by credential id', () => {
-        const credentialEnittyTemplate = {
+        const credentialEntityTemplate = {
           propertyName: 'givenName',
           propertyValue: 'Mark',
           id: 0,
@@ -63,14 +63,14 @@ describe('lib/storage', () => {
         }
 
         const mockCredential: CredentialEntity[] = [
-          credentialEnittyTemplate,
+          credentialEntityTemplate,
           {
-            ...credentialEnittyTemplate,
+            ...credentialEntityTemplate,
             propertyName: 'familyName',
             propertyValue: 'Musterman',
           },
           {
-            ...credentialEnittyTemplate,
+            ...credentialEntityTemplate,
             propertyName: 'email',
             propertyValue: 'test@example.com',
             verifiableCredential: {


### PR DESCRIPTION
Some of the transformations happening in the `groupAttributesByCredentialId` function were a bit difficult to make sense of. Unit tests were also missing.

This PR includes an extra basic unit test and a slight refactor + documentation of the aforementioned function.