### PR TITLE
Fix keychain issue after app uninstall

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
-      android:allowBackup="true"
+      android:allowBackup="false"
       android:theme="@style/AppTheme">
       <activity
         android:name=".MainActivity"

--- a/src/backendMiddleware.ts
+++ b/src/backendMiddleware.ts
@@ -94,6 +94,12 @@ export class BackendMiddleware {
     }
 
     if (!encryptedEntropy || !encryptionPass) {
+      // If either encryptedEntropy or encryptionPass was missing, we throw
+      // NoEntropy to signal that we cannot prepare an identityWallet instance due
+      // to lack of a seed.
+      // Note that the case of having an encryptionPass but no encryptedEntropy
+      // is an uncommon edge case, but may potentially happen due to errors/bugs
+      // etc
       throw new BackendError(ErrorCodes.NoEntropy)
     }
 

--- a/src/backendMiddleware.ts
+++ b/src/backendMiddleware.ts
@@ -83,14 +83,17 @@ export class BackendMiddleware {
     } catch (e) {
       // This may fail if the application was uninstalled and reinstalled, as
       // the android keystore is cleared on uninstall, but the database may
-      // still remain.
+      // still remain, due to having been auto backed up!
       // FIXME: Sentry.captureException(e)
     }
 
+    if (encryptedEntropy && !encryptionPass) {
+      // if we can't decrypt the encryptedEntropy, then reset the database
+      console.warn('DROPPING OLD DB')
+      await this.storageLib.resetDatabase()
+    }
+
     if (!encryptedEntropy || !encryptionPass) {
-      // if we can't decrypt the encryptedEntropy, then delete it
-      if (encryptedEntropy)
-        this.storageLib.delete.encryptedSeed(encryptedEntropy)
       throw new BackendError(ErrorCodes.NoEntropy)
     }
 

--- a/src/lib/storage/migration/1567674609659-reencrypt-seed.ts
+++ b/src/lib/storage/migration/1567674609659-reencrypt-seed.ts
@@ -15,8 +15,18 @@ export class ReencryptSeed1567674609659 implements MigrationInterface {
 
     if (!entries.length) return
 
-    // note we don't try to get a password if there is nothing to re-encrypt
-    const password = await getPassword()
+    let password: string
+    try {
+      // If there are keys to re-encrypt, then we need to get the password.
+      password = await getPassword()
+    } catch (e) {
+      // This may fail if the application was uninstalled and reinstalled, as
+      // the android keystore is cleared on uninstall, but the database may
+      // still remain (and is probably pre-migrations, given that this is
+      // running in the first place). In that case we take no action, and let
+      // the app init code handle things
+      return
+    }
 
     await Promise.all(
       entries.map((obj: any) => {

--- a/src/lib/storage/storage.ts
+++ b/src/lib/storage/storage.ts
@@ -83,6 +83,7 @@ export class Storage {
 
   public delete = {
     verifiableCredential: this.deleteVCred.bind(this),
+    encryptedSeed: this.deleteEncryptedSeed.bind(this),
     // credentialMetadata: this.deleteCredentialMetadata.bind(this)
   }
 
@@ -213,6 +214,15 @@ export class Storage {
     await this.createConnectionIfNeeded()
     const encryptedSeed = plainToClass(MasterKeyEntity, args)
     await this.connection.manager.save(encryptedSeed)
+  }
+
+  private async deleteEncryptedSeed(encryptedEntropy: string): Promise<void> {
+    await this.createConnectionIfNeeded()
+    await this.connection.manager.createQueryBuilder()
+      .delete()
+      .from(MasterKeyEntity)
+      .where("encryptedEntropy = :encryptedEntropy", { encryptedEntropy })
+      .execute()
   }
 
   private async storeVClaim(vCred: SignedCredential): Promise<void> {

--- a/src/lib/storage/storage.ts
+++ b/src/lib/storage/storage.ts
@@ -97,6 +97,14 @@ export class Storage {
     }
   }
 
+  public async resetDatabase() {
+    await this.createConnectionIfNeeded()
+    await this.connection.dropDatabase()
+    await this.connection.close()
+    this.connectionPromise = null
+    await this.createConnectionIfNeeded()
+  }
+
   private async createConnectionIfNeeded(): Promise<Connection> {
     if (this.connectionPromise) return this.connectionPromise
     return (this.connectionPromise = createConnection(this.config)

--- a/src/lib/storage/storage.ts
+++ b/src/lib/storage/storage.ts
@@ -83,7 +83,6 @@ export class Storage {
 
   public delete = {
     verifiableCredential: this.deleteVCred.bind(this),
-    encryptedSeed: this.deleteEncryptedSeed.bind(this),
     // credentialMetadata: this.deleteCredentialMetadata.bind(this)
   }
 
@@ -222,15 +221,6 @@ export class Storage {
     await this.createConnectionIfNeeded()
     const encryptedSeed = plainToClass(MasterKeyEntity, args)
     await this.connection.manager.save(encryptedSeed)
-  }
-
-  private async deleteEncryptedSeed(encryptedEntropy: string): Promise<void> {
-    await this.createConnectionIfNeeded()
-    await this.connection.manager.createQueryBuilder()
-      .delete()
-      .from(MasterKeyEntity)
-      .where("encryptedEntropy = :encryptedEntropy", { encryptedEntropy })
-      .execute()
   }
 
   private async storeVClaim(vCred: SignedCredential): Promise<void> {


### PR DESCRIPTION
Keystore is cleared on uninstall, so encryptedSeed cannot be decrypted and must be deleted to let the app go back to the "getting started / recovery" state. Furthermore the "re-encrypt" migration was also fixed.

Related to and potentially fixes #1240 but needs further testing.