### PR TITLE
fix(consent): pre-select the first available cred of each type

### DIFF
--- a/src/ui/sso/components/consent.tsx
+++ b/src/ui/sso/components/consent.tsx
@@ -64,7 +64,7 @@ export class ConsentComponent extends React.Component<Props, State> {
   public state = {
     pending: false,
     selectedCredentials: this.props.availableCredentials.reduce(
-      (acc, curr) => ({ ...acc, [curr.type]: undefined }),
+      (acc, curr) => ({ ...acc, [curr.type]: acc[curr.type] || curr.verifications[0] }),
       {},
     ),
   }


### PR DESCRIPTION
When sharing credentials, select defaults to be shared from the list of appropriate available credentials.