### PR TITLE
Default to EN, remove language picker

### DIFF
--- a/src/actions/generic/index.ts
+++ b/src/actions/generic/index.ts
@@ -33,9 +33,15 @@ export const initApp: ThunkAction = async (
   try {
     await backendMiddleware.initStorage()
     const storedSettings = await backendMiddleware.storageLib.get.settingsObject()
-    // locale setup
-    if (storedSettings.locale) I18n.locale = storedSettings.locale
-    else storedSettings.locale = I18n.locale
+
+    /**
+     * @dev Until German and Dutch terms are polished, only English is used.
+     * previous code:
+     * if (storedSettings.locale) I18n.locale = storedSettings.locale
+     * else storedSettings.locale = I18n.locale
+     */
+    storedSettings.locale = I18n.locale
+
     SplashScreen.hide()
     return dispatch(loadSettings(storedSettings))
   } catch (e) {

--- a/src/actions/sso/consumeInteractionToken.ts
+++ b/src/actions/sso/consumeInteractionToken.ts
@@ -2,8 +2,7 @@ import { JolocomLib } from 'jolocom-lib'
 import { interactionHandlers } from '../../lib/storage/interactionTokens'
 import { withErrorScreen, withLoading } from '../modifiers'
 import { showErrorScreen } from '../generic'
-import { AppError } from '../../lib/errors'
-import ErrorCode from '../../lib/errorCodes'
+import { AppError, ErrorCode } from '../../lib/errors'
 import { ThunkAction } from '../../store'
 import {
   JSONWebToken,

--- a/src/locales/i18n.ts
+++ b/src/locales/i18n.ts
@@ -3,7 +3,6 @@
 // see
 // https://github.com/react-native-community/react-native-localize/blob/master/example/src/AsyncExample.js
 
-import * as RNLocalize from 'react-native-localize'
 import I18n from 'i18n-js'
 
 const de = require('./de.json')
@@ -18,10 +17,17 @@ I18n.translations = {
 }
 export const locales = ['en', 'de', 'nl']
 
-const fallback = { languageTag: 'en', isRTL: false }
-const { languageTag } =
-  RNLocalize.findBestAvailableLanguage(locales) || fallback
-I18n.locale = languageTag
+const defaultLocale = { languageTag: 'en', isRTL: false }
+
+/** @dev Only english is offered until the Dutch and German terms are polished, previous code:
+*
+* import * as RNLocalize from 'react-native-localize'
+* const { languageTag } =
+* RNLocalize.findBestAvailableLanguage(locales) || fallback
+* I18n.locale = languageTag
+*/
+
+I18n.locale = defaultLocale.languageTag
 
 const localeSpecificImages = {
   en: {

--- a/src/ui/settings/containers/settings.tsx
+++ b/src/ui/settings/containers/settings.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import VersionNumber from 'react-native-version-number'
 import { StyleSheet, Text, View, ScrollView } from 'react-native'
-import I18n, { locales } from 'src/locales/i18n'
+import I18n from 'src/locales/i18n'
 import strings from '../../../locales/strings'
 import { Colors, Spacing, Typography } from 'src/styles'
 import { Wrapper } from 'src/ui/structure'
@@ -12,7 +12,6 @@ import { routeList } from 'src/routeList'
 import { withErrorScreen, withLoading } from '../../../actions/modifiers'
 import { genericActions, navigationActions } from '../../../actions'
 import { connect } from 'react-redux'
-import { LocaleSetting } from '../components/localeSetting'
 import SettingItem from '../components/settingItem'
 import settingKeys from '../settingKeys'
 import { showSeedPhrase } from '../../../actions/recovery'
@@ -41,9 +40,9 @@ interface Props
     ReturnType<typeof mapDispatchToProps> {}
 
 export const SettingsContainer: React.FC<Props> = props => {
-  const { setLocale, settings, setupBackup, navigate } = props
+  const {  settings, setupBackup, navigate } = props
   const version = VersionNumber.appVersion
-  const currentLocale = settings.locale
+  // const currentLocale = settings.locale
   const seedPhraseSaved = settings[settingKeys.seedPhraseSaved] as boolean
   return (
     <Wrapper style={styles.container}>
@@ -66,13 +65,15 @@ export const SettingsContainer: React.FC<Props> = props => {
             />
           </SettingSection>
         )}
-        <SettingSection title={I18n.t(strings.YOUR_PREFERENCES)}>
-          <LocaleSetting
-            locales={locales}
-            currentLocale={currentLocale}
-            setLocale={setLocale}
-          />
-        </SettingSection>
+        {/*
+          <SettingSection title={I18n.t(strings.YOUR_PREFERENCES)}>
+            <LocaleSetting
+              locales={locales}
+              currentLocale={currentLocale}
+              setLocale={setLocale}
+            />
+          </SettingSection>
+        */}
         <SettingSection title={I18n.t(strings.SECURITY)}>
           <SettingItem
             title={I18n.t(strings.BACKUP_YOUR_IDENTITY)}


### PR DESCRIPTION
Setting English as the default language on the wallet for now. The Dutch and German translations need to be polished and aligned with our general tone of voice.