### PR TITLE
Interaction Manager service-side flows

### DIFF
--- a/src/actions/sso/credentialOffer.ts
+++ b/src/actions/sso/credentialOffer.ts
@@ -18,6 +18,7 @@ import { isEmpty, uniqBy } from 'ramda'
 import { SignedCredential } from 'jolocom-lib/js/credentials/signedCredential/signedCredential'
 import { CredentialMetadataSummary } from 'src/lib/storage/storage'
 import { CacheEntity } from 'src/lib/storage/entities'
+import { CredentialOfferFlow } from 'src/lib/interactionManager/credentialOfferFlow'
 
 export const consumeCredentialOfferRequest = (
   credentialOfferRequest: JSONWebToken<CredentialOfferRequest>,
@@ -91,8 +92,7 @@ export const validateSelectionAndSave = (
   { interactionManager, storageLib },
 ) => {
   const interaction = interactionManager.getInteraction(interactionId)
-  const { offerSummary } = interaction.getSummary()
-    .state as CredentialOfferFlowState
+  const offerSummary = (interaction.flow as CredentialOfferFlow).getIssuanceResult()
 
   const selectedTypes = selectedCredentials.map(el => el.type)
   const toSave = offerSummary.filter(el => selectedTypes.includes(el.type))

--- a/src/actions/sso/credentialOffer.ts
+++ b/src/actions/sso/credentialOffer.ts
@@ -140,7 +140,7 @@ export const validateSelectionAndSave = (
 
     await storeOfferMetadata(
       (interaction.getSummary().state as CredentialOfferFlowState).offerSummary,
-      interaction.participants.them.did,
+      interaction.participants.requester.did,
       storageLib.store.credentialMetadata,
     )
 

--- a/src/actions/sso/credentialRequest.ts
+++ b/src/actions/sso/credentialRequest.ts
@@ -7,6 +7,7 @@ import { CredentialVerificationSummary } from 'src/lib/interactionManager/types'
 import { InteractionChannel } from 'src/lib/interactionManager/types'
 import { Interaction } from 'src/lib/interactionManager/interaction'
 import { cancelSSO } from './'
+import { CredentialRequestFlow } from 'src/lib/interactionManager/credentialRequestFlow'
 
 export const consumeCredentialRequest = (
   credentialRequest: JSONWebToken<CredentialRequest>,
@@ -25,6 +26,9 @@ export const consumeCredentialRequest = (
       params: {
         interactionId: interaction.id,
         interactionSummary: interaction.getSummary(),
+        availableCreds: await (interaction.flow as CredentialRequestFlow).getAvailableCredentials(
+          credentialRequest.interactionToken,
+        ),
       },
       key: 'credentialRequest',
     }),

--- a/src/lib/interactionManager/authenticationFlow.ts
+++ b/src/lib/interactionManager/authenticationFlow.ts
@@ -28,6 +28,8 @@ export class AuthenticationFlow extends Flow {
   }
 
   public async consumeAuthenticationRequest(token: Authentication) {
-    this.state.description = token.description
+    if (!this.state.description) this.state.description = token.description
+
+    return this.state.description === token.description
   }
 }

--- a/src/lib/interactionManager/credentialOfferFlow.ts
+++ b/src/lib/interactionManager/credentialOfferFlow.ts
@@ -57,6 +57,16 @@ export class CredentialOfferFlow extends Flow {
   // also populates the SignedCredentialWithMetadata with credentials
   private handleCredentialReceive({ signedCredentials }: CredentialsReceive) {
     this.state.issued = signedCredentials
+    this.state.issued.map(cred => {
+      const offer = this.state.offerSummary.find(
+        ({ type }) => type === last(cred.type),
+      )
+
+      if (!offer) {
+        throw new Error('Received wrong credentials')
+      }
+    })
+
     return true
   }
 

--- a/src/lib/interactionManager/credentialOfferFlow.ts
+++ b/src/lib/interactionManager/credentialOfferFlow.ts
@@ -72,9 +72,9 @@ export class CredentialOfferFlow extends Flow {
           // This signals funny things in the flow without throwing errors. We don't simply throw because often times
           // negotiation is still possible on the UI / UX layer, and the interaction can continue.
           invalidIssuer:
-            signedCredential.issuer !== this.ctx.participants.them.did,
+            signedCredential.issuer !== this.ctx.participants.requester.did,
           invalidSubject:
-            signedCredential.subject !== this.ctx.participants.us.did,
+            signedCredential.subject !== this.ctx.participants.responder!.did,
         },
       }
     })

--- a/src/lib/interactionManager/credentialOfferFlow.ts
+++ b/src/lib/interactionManager/credentialOfferFlow.ts
@@ -60,6 +60,14 @@ export class CredentialOfferFlow extends Flow {
     return true
   }
 
+  // return a list of types which are both offered and requested
+  public getSelectionResult(): string[] {
+    const offeredTypes = this.state.offerSummary.map(o => o.type)
+    const selectedTypes = this.state.selection.map(s => s.type)
+
+    return offeredTypes.filter(ot => selectedTypes.includes(ot))
+  }
+
   public getIssuanceResult(): IssuanceResult {
     return this.state.issued.map(cred => {
       const offer = this.state.offerSummary.find(

--- a/src/lib/interactionManager/credentialOfferFlow.ts
+++ b/src/lib/interactionManager/credentialOfferFlow.ts
@@ -25,7 +25,7 @@ export class CredentialOfferFlow extends Flow {
   public async handleInteractionToken(
     token: JWTEncodable,
     messageType: InteractionType,
-  ): Promise<any> {
+  ): Promise<boolean> {
     switch (messageType) {
       case InteractionType.CredentialOfferRequest:
         if (isCredentialOfferRequest(token))
@@ -46,11 +46,12 @@ export class CredentialOfferFlow extends Flow {
       ...offer,
       validationErrors: {},
     }))
+    return true
   }
 
   // Not relevant for client (?)
   private async handleOfferResponse(token: CredentialOfferResponse) {
-    return
+    return false
   }
 
   // Sets the validity map, currently if the issuer and if the subjects are correct.
@@ -78,5 +79,6 @@ export class CredentialOfferFlow extends Flow {
         },
       }
     })
+    return true
   }
 }

--- a/src/lib/interactionManager/credentialRequestFlow.ts
+++ b/src/lib/interactionManager/credentialRequestFlow.ts
@@ -12,7 +12,8 @@ import { isCredentialRequest, isCredentialResponse } from './guards'
 
 export class CredentialRequestFlow extends Flow {
   public state: CredentialRequestFlowState = {
-    availableCredentials: [],
+    constraints: [],
+    providedCredentials: [],
   }
 
   constructor(ctx: Interaction) {
@@ -41,6 +42,10 @@ export class CredentialRequestFlow extends Flow {
   }
 
   private async handleCredentialRequest(request: CredentialRequest) {
+    this.state.constraints.push(request)
+  }
+
+  public async getAvailableCredentials(request: CredentialRequest) {
     const { requestedCredentialTypes } = request
 
     const attributesForType = await Promise.all<AttributeSummary>(
@@ -85,11 +90,12 @@ export class CredentialRequestFlow extends Flow {
       })),
     )
 
-    this.state.availableCredentials = abbreviated.reduce((acc, val) =>
-      acc.concat(val),
-    )
+    return abbreviated.reduce((acc, val) => acc.concat(val))
   }
 
   // Currently no validation here
-  public handleCredentialResponse(token: CredentialResponse) {}
+  private handleCredentialResponse(token: CredentialResponse) {
+    this.state.providedCredentials.push(token)
+    token.satisfiesRequest(this.state.constraints[-1])
+  }
 }

--- a/src/lib/interactionManager/credentialRequestFlow.ts
+++ b/src/lib/interactionManager/credentialRequestFlow.ts
@@ -79,7 +79,7 @@ export class CredentialRequestFlow extends Flow {
           issuer: {
             did: vCred.issuer,
           },
-          selfSigned: vCred.signer.did === this.ctx.participants.us.did,
+          selfSigned: vCred.signer.did === this.ctx.participants.responder!.did,
           expires: vCred.expires,
         })),
       })),

--- a/src/lib/interactionManager/credentialRequestFlow.ts
+++ b/src/lib/interactionManager/credentialRequestFlow.ts
@@ -43,6 +43,12 @@ export class CredentialRequestFlow extends Flow {
 
   private async handleCredentialRequest(request: CredentialRequest) {
     this.state.constraints.push(request)
+    return true
+  }
+
+  private async handleCredentialResponse(token: CredentialResponse) {
+    this.state.providedCredentials.push(token)
+    return token.satisfiesRequest(this.state.constraints[-1])
   }
 
   public async getAvailableCredentials(request: CredentialRequest) {
@@ -91,11 +97,5 @@ export class CredentialRequestFlow extends Flow {
     )
 
     return abbreviated.reduce((acc, val) => acc.concat(val))
-  }
-
-  // Currently no validation here
-  private handleCredentialResponse(token: CredentialResponse) {
-    this.state.providedCredentials.push(token)
-    token.satisfiesRequest(this.state.constraints[-1])
   }
 }

--- a/src/lib/interactionManager/flow.ts
+++ b/src/lib/interactionManager/flow.ts
@@ -15,7 +15,7 @@ export abstract class Flow {
   abstract async handleInteractionToken(
     token: JWTEncodable,
     messageType: InteractionType,
-  ): Promise<void>
+  ): Promise<boolean>
 
   public getState() {
     return this.state

--- a/src/lib/interactionManager/interaction.ts
+++ b/src/lib/interactionManager/interaction.ts
@@ -169,8 +169,9 @@ export class Interaction {
 
     return this.flow
       .handleInteractionToken(token.interactionToken, token.interactionType)
-      .then(() => {
+      .then(res => {
         this.interactionMessages.push(token)
+        return res
       })
   }
 

--- a/src/lib/interactionManager/types.ts
+++ b/src/lib/interactionManager/types.ts
@@ -1,4 +1,7 @@
-import { CredentialOffer } from 'jolocom-lib/js/interactionTokens/interactionTokens.types'
+import {
+  CredentialOffer,
+  CredentialOfferResponseSelection,
+} from 'jolocom-lib/js/interactionTokens/interactionTokens.types'
 import { SignedCredential } from 'jolocom-lib/js/credentials/signedCredential/signedCredential'
 import { IdentitySummary } from '../../actions/sso/types'
 import { FlowState } from './flow'
@@ -29,9 +32,9 @@ export interface CredentialRequestFlowState extends FlowState {
 }
 
 export interface CredentialOfferFlowState extends FlowState {
-  offerSummary: Array<
-    SignedCredentialWithMetadata & { validationErrors: ValidationErrorMap }
-  >
+  offerSummary: CredentialOffer[]
+  selection: CredentialOfferResponseSelection[]
+  issued: SignedCredential[]
 }
 
 export interface CredentialTypeSummary {
@@ -55,6 +58,10 @@ export interface AttributeSummary {
     values: string[]
   }>
 }
+
+export type IssuanceResult = Array<
+  SignedCredentialWithMetadata & { validationErrors: ValidationErrorMap }
+>
 
 type ValidationErrorMap = {
   invalidIssuer?: boolean

--- a/src/lib/interactionManager/types.ts
+++ b/src/lib/interactionManager/types.ts
@@ -5,7 +5,7 @@ import { FlowState } from './flow'
 
 // TODO define and refactor how the UI components/containers handle the InteractionSummary.
 export interface InteractionSummary {
-  issuer: IdentitySummary
+  initiator: IdentitySummary
   state: FlowState
 }
 

--- a/src/lib/interactionManager/types.ts
+++ b/src/lib/interactionManager/types.ts
@@ -2,6 +2,8 @@ import { CredentialOffer } from 'jolocom-lib/js/interactionTokens/interactionTok
 import { SignedCredential } from 'jolocom-lib/js/credentials/signedCredential/signedCredential'
 import { IdentitySummary } from '../../actions/sso/types'
 import { FlowState } from './flow'
+import { CredentialRequest } from 'jolocom-lib/js/interactionTokens/credentialRequest'
+import { CredentialResponse } from 'jolocom-lib/js/interactionTokens/credentialResponse'
 
 // TODO define and refactor how the UI components/containers handle the InteractionSummary.
 export interface InteractionSummary {
@@ -22,7 +24,8 @@ export interface AuthenticationFlowState extends FlowState {
 }
 
 export interface CredentialRequestFlowState extends FlowState {
-  availableCredentials: CredentialTypeSummary[]
+  constraints: CredentialRequest[]
+  providedCredentials: CredentialResponse[]
 }
 
 export interface CredentialOfferFlowState extends FlowState {

--- a/src/ui/authentication/components/authenticationConsent.tsx
+++ b/src/ui/authentication/components/authenticationConsent.tsx
@@ -61,12 +61,12 @@ export class AuthenticationConsentComponent extends React.Component<
   }
 
   public render() {
-    const { issuer, state } = this.props.interactionSummary
+    const { initiator, state } = this.props.interactionSummary
     const { description } = state as AuthenticationFlowState
     return (
       <View style={styles.container}>
         <View style={styles.topSection}>
-          <IssuerCard issuer={issuer} style={styles.issuerCard} />
+          <IssuerCard issuer={initiator} style={styles.issuerCard} />
           <View style={styles.authRequestContainer}>
             <Text style={styles.authRequestText}>
               {I18n.t(strings.WOULD_YOU_LIKE_TO)}

--- a/src/ui/sso/components/credentialReceive.tsx
+++ b/src/ui/sso/components/credentialReceive.tsx
@@ -10,6 +10,7 @@ import { DocumentReceiveCard } from './documentReceiveCard'
 import {
   SignedCredentialWithMetadata,
   CredentialOfferFlowState,
+  IssuanceResult,
 } from '../../../lib/interactionManager/types'
 import LinearGradient from 'react-native-linear-gradient'
 
@@ -73,7 +74,7 @@ const styles = StyleSheet.create({
 
 interface Props {
   publicProfile: IssuerPublicProfileSummary
-  credentialOfferSummary: CredentialOfferFlowState
+  credentialOfferSummary: IssuanceResult
   onToggleSelect: (offering: SignedCredentialWithMetadata) => void
   isDocumentSelected: (offering: SignedCredentialWithMetadata) => boolean
 }
@@ -81,7 +82,7 @@ interface Props {
 export const CredentialReceiveComponent = (props: Props) => {
   const {
     publicProfile,
-    credentialOfferSummary: { offerSummary },
+    credentialOfferSummary,
     onToggleSelect,
     isDocumentSelected,
   } = props
@@ -187,7 +188,7 @@ export const CredentialReceiveComponent = (props: Props) => {
             )}
           </Text>
         </Animated.View>
-        {offerSummary.map((offer, i) => {
+        {credentialOfferSummary.map((offer, i) => {
           const { validationErrors } = offer
           return (
             <DocumentReceiveCard

--- a/src/ui/sso/containers/consent.tsx
+++ b/src/ui/sso/containers/consent.tsx
@@ -42,12 +42,12 @@ const ConsentContainer = (props: Props) => {
     sendCredentialResponse(credentials, interactionId)
   }
 
-  const { issuer, state } = interactionSummary
+  const { initiator, state } = interactionSummary
 
   // TODO Instead of "as", use type guards?
   return (
     <ConsentComponent
-      requester={issuer}
+      requester={initiator}
       did={currentDid}
       availableCredentials={
         (state as CredentialRequestFlowState).availableCredentials

--- a/src/ui/sso/containers/consent.tsx
+++ b/src/ui/sso/containers/consent.tsx
@@ -7,7 +7,6 @@ import { withLoading, withErrorScreen } from 'src/actions/modifiers'
 import {
   CredentialTypeSummary,
   CredentialVerificationSummary,
-  CredentialRequestFlowState,
 } from 'src/lib/interactionManager/types'
 import { NavigationScreenProp, NavigationState } from 'react-navigation'
 import { InteractionSummary } from '../../../lib/interactionManager/types'
@@ -15,6 +14,7 @@ import { InteractionSummary } from '../../../lib/interactionManager/types'
 interface CredentialRequestNavigationParams {
   interactionId: string
   interactionSummary: InteractionSummary
+  availableCredentials: Array<CredentialTypeSummary>
 }
 
 interface Props
@@ -33,7 +33,7 @@ const ConsentContainer = (props: Props) => {
     cancelSSO,
     navigation: {
       state: {
-        params: { interactionId, interactionSummary },
+        params: { interactionId, interactionSummary, availableCredentials },
       },
     },
   } = props
@@ -42,16 +42,14 @@ const ConsentContainer = (props: Props) => {
     sendCredentialResponse(credentials, interactionId)
   }
 
-  const { initiator, state } = interactionSummary
+  const { initiator } = interactionSummary
 
   // TODO Instead of "as", use type guards?
   return (
     <ConsentComponent
       requester={initiator}
       did={currentDid}
-      availableCredentials={
-        (state as CredentialRequestFlowState).availableCredentials
-      }
+      availableCredentials={availableCredentials}
       handleSubmitClaims={handleSubmitClaims}
       handleDenySubmit={cancelSSO}
     />

--- a/src/ui/sso/containers/credentialReceive.tsx
+++ b/src/ui/sso/containers/credentialReceive.tsx
@@ -37,7 +37,7 @@ export const CredentialsReceiveContainer = (props: Props) => {
     },
   } = navigation
 
-  const { publicProfile } = interactionSummary.issuer
+  const { publicProfile } = interactionSummary.initiator
 
   const handleConfirm = () => {
     acceptSelectedCredentials(selected, interactionId)


### PR DESCRIPTION
Makes a few changes:

- [x] make the interaction participants not dependant on which role the SDK instance is performing
- [x] make the states of the interaction flows directly represent the messages exchanged, not derived from them for a particular role (e.g. availableCredentials is not useful for an issuer in the credOffer flow)
- [x] changes cred request flow to be role-agnostic
- [x] changes cred offer flow to be role-agnostic
- [x] changes auth flow to be role-agnostic
- [x] return a `Promise<boolean>` from `processInteractionToken` which represents either valid state change, invalid state change (e.g. doesnt meet requirements for flow) or invalid token format/signatures (if the promise rejects). This enables a service to evaluate the result of a response without digging into the internals of the interactions or interaction manager. The result of this function was previously unused.