### PR TITLE
Fix Cred Offer bug

### DIFF
--- a/src/ui/sso/components/documentReceiveCard.tsx
+++ b/src/ui/sso/components/documentReceiveCard.tsx
@@ -103,9 +103,8 @@ export const DocumentReceiveCard = (props: Props) => {
 
   //NOTE: @onSnap will fire if the animation/selection wasn't handled by @onDrag.
   const onSnap = (e: ISnapEvent) => {
-    if (e.nativeEvent.index === 1) {
-      if (!selected) onSelect()
-      else onUnselect()
+    if (e.nativeEvent.index === 1 && selected) {
+      onUnselect()
     }
   }
 


### PR DESCRIPTION
Due to [1619](https://github.com/jolocom/smartwallet-app/pull/1619), the same credential was stored twice (due to a small bug), causing a TypeORM error. 