### PR TITLE
Change Pin Instructions styling adjustments

### DIFF
--- a/src/ui/deviceauth/HowToChangePIN.tsx
+++ b/src/ui/deviceauth/HowToChangePIN.tsx
@@ -48,8 +48,8 @@ const HowToChangePIN: React.FC<PropsI> = ({
           color={Colors.white80}
           customStyles={{
             marginTop: BP({ small: 0, medium: 12, large: 24 }),
-            fontSize: BP({ small: 16, medium: 16, large: 20 }),
-            lineHeight: BP({ small: 18, medium: 18, large: 22 }),
+            fontSize: BP({ small: 16, medium: 18, large: 20 }),
+            lineHeight: BP({ small: 18, medium: 20, large: 22 }),
             alignSelf: 'flex-start',
             textAlign: 'left',
           }}>
@@ -58,8 +58,8 @@ const HowToChangePIN: React.FC<PropsI> = ({
         <Paragraph
           color={Colors.white80}
           customStyles={{
-            fontSize: BP({ small: 16, medium: 16, large: 20 }),
-            lineHeight: BP({ small: 18, medium: 18, large: 22 }),
+            fontSize: BP({ small: 16, medium: 18, large: 20 }),
+            lineHeight: BP({ small: 18, medium: 20, large: 22 }),
             alignSelf: 'flex-start',
             textAlign: 'left',
             marginTop: 18,
@@ -70,7 +70,7 @@ const HowToChangePIN: React.FC<PropsI> = ({
           style={{
             transform: [{ scale: BP({ small: 0.7, medium: 1, large: 1 }) }],
             position: 'absolute',
-            bottom: BP({ small: -80, medium: -70, large: -50 }),
+            bottom: BP({ small: -80, medium: -80, large: -50 }),
           }}>
           <RecoveryInstructions />
         </View>

--- a/src/ui/deviceauth/HowToChangePIN.tsx
+++ b/src/ui/deviceauth/HowToChangePIN.tsx
@@ -4,7 +4,6 @@ import { connect } from 'react-redux'
 
 import I18n from 'src/locales/i18n'
 
-import ScreenContainer from './components/ScreenContainer'
 import Header from './components/Header'
 import Paragraph, { ParagraphSizes } from './components/Paragraph'
 import Btn, { BtnTypes } from './components/Btn'
@@ -16,6 +15,8 @@ import { BP } from '../../styles/breakpoints'
 import { navigationActions } from 'src/actions'
 import { routeList } from 'src/routeList'
 import RecoveryInstructions from 'src/resources/svg/ForgotPINInstructions'
+import { Wrapper } from '../structure'
+import PasscodeWrapper from './components/PasscodeWrapper'
 
 interface PropsI {
   handleGoBack: () => void
@@ -26,70 +27,74 @@ const HowToChangePIN: React.FC<PropsI> = ({
   handleAccessRestore,
 }) => {
   return (
-    <ScreenContainer
+    <Wrapper
       customStyles={{
         backgroundColor: Colors.black,
-        justifyContent: 'flex-start',
-        paddingTop: BP({ small: 30, medium: 50, large: 50 }),
-        paddingHorizontal: 20,
       }}>
-      <Header
-        color={Colors.white90}
+      <PasscodeWrapper
         customStyles={{
-          fontSize: BP({ small: 24, medium: 28, large: 28 }),
-          alignSelf: 'flex-start',
+          paddingTop: BP({ small: 30, medium: 50, large: 50 }),
+          paddingHorizontal: BP({ small: 16, medium: 20, large: 30 }),
         }}>
-        {I18n.t(strings.HOW_TO_CHANGE_PIN)}
-      </Header>
-      <Paragraph
-        color={Colors.white80}
-        customStyles={{
-          alignSelf: 'flex-start',
-          textAlign: 'left',
-          lineHeight: 17,
-        }}>
-        {I18n.t(strings.WE_ARE_SORRY_THAT_YOU_FORGOT)}
-      </Paragraph>
-      <Paragraph
-        color={Colors.white80}
-        customStyles={{
-          alignSelf: 'flex-start',
-          textAlign: 'left',
-          lineHeight: 17,
-          marginTop: 10,
-        }}>
-        {I18n.t(strings.YOU_CAN_CHANGE_PIN)}
-      </Paragraph>
-      <View
-        style={{
-          transform: [{ scale: BP({ small: 0.75, medium: 1, large: 1 }) }],
-          position: 'absolute',
-          bottom: BP({ small: -70, medium: -50, large: -50 }),
-        }}>
-        <RecoveryInstructions />
-      </View>
-      <AbsoluteBottom customStyles={{ alignSelf: 'center', bottom: 0 }}>
-        <Btn onPress={handleAccessRestore}>
-          {I18n.t(strings.RESTORE_ACCESS)}
-        </Btn>
-        <Paragraph
-          size={ParagraphSizes.micro}
-          color={Colors.white70}
+        <Header
+          color={Colors.white90}
           customStyles={{
-            paddingHorizontal: BP({
-              small: 10,
-              medium: 25,
-              large: 25,
-            }),
-            lineHeight: 15,
+            fontSize: BP({ small: 24, medium: 28, large: 28 }),
+            alignSelf: 'flex-start',
           }}>
-          {I18n.t(strings.STORING_NO_AFFECT_DATA)}
+          {I18n.t(strings.HOW_TO_CHANGE_PIN)}
+        </Header>
+        <Paragraph
+          color={Colors.white80}
+          customStyles={{
+            marginTop: 24,
+            alignSelf: 'flex-start',
+            textAlign: 'left',
+            lineHeight: 17,
+          }}>
+          {I18n.t(strings.WE_ARE_SORRY_THAT_YOU_FORGOT)}
         </Paragraph>
-        <Btn onPress={handleGoBack} type={BtnTypes.secondary}>
-          {I18n.t(strings.CANCEL)}
-        </Btn>
-      </AbsoluteBottom>
-    </ScreenContainer>
+        <Paragraph
+          color={Colors.white80}
+          customStyles={{
+            alignSelf: 'flex-start',
+            textAlign: 'left',
+            lineHeight: 17,
+            marginTop: 17,
+          }}>
+          {I18n.t(strings.YOU_CAN_CHANGE_PIN)}
+        </Paragraph>
+        <View
+          style={{
+            transform: [{ scale: BP({ small: 0.75, medium: 1, large: 1 }) }],
+            position: 'absolute',
+            bottom: BP({ small: -70, medium: -50, large: -50 }),
+          }}>
+          <RecoveryInstructions />
+        </View>
+        <AbsoluteBottom customStyles={{ alignSelf: 'center', bottom: 0 }}>
+          <Btn onPress={handleAccessRestore}>
+            {I18n.t(strings.RESTORE_ACCESS)}
+          </Btn>
+          <Paragraph
+            size={ParagraphSizes.micro}
+            color={Colors.white70}
+            customStyles={{
+              paddingHorizontal: BP({
+                small: 10,
+                medium: 25,
+                large: 25,
+              }),
+              lineHeight: 15,
+            }}>
+            {I18n.t(strings.STORING_NO_AFFECT_DATA)}
+          </Paragraph>
+          <Btn onPress={handleGoBack} type={BtnTypes.secondary}>
+            {I18n.t(strings.CANCEL)}
+          </Btn>
+        </AbsoluteBottom>
+      </PasscodeWrapper>
+    </Wrapper>
   )
 }
 

--- a/src/ui/deviceauth/HowToChangePIN.tsx
+++ b/src/ui/deviceauth/HowToChangePIN.tsx
@@ -48,19 +48,21 @@ const HowToChangePIN: React.FC<PropsI> = ({
           color={Colors.white80}
           customStyles={{
             marginTop: 24,
+            fontSize: BP({ small: 16, medium: 16, large: 20 }),
+            lineHeight: BP({ small: 18, medium: 18, large: 22 }),
             alignSelf: 'flex-start',
             textAlign: 'left',
-            lineHeight: 17,
           }}>
           {I18n.t(strings.WE_ARE_SORRY_THAT_YOU_FORGOT)}
         </Paragraph>
         <Paragraph
           color={Colors.white80}
           customStyles={{
+            fontSize: BP({ small: 16, medium: 16, large: 20 }),
+            lineHeight: BP({ small: 18, medium: 18, large: 22 }),
             alignSelf: 'flex-start',
             textAlign: 'left',
-            lineHeight: 17,
-            marginTop: 17,
+            marginTop: 18,
           }}>
           {I18n.t(strings.YOU_CAN_CHANGE_PIN)}
         </Paragraph>

--- a/src/ui/deviceauth/HowToChangePIN.tsx
+++ b/src/ui/deviceauth/HowToChangePIN.tsx
@@ -33,7 +33,7 @@ const HowToChangePIN: React.FC<PropsI> = ({
       }}>
       <PasscodeWrapper
         customStyles={{
-          paddingTop: BP({ small: 30, medium: 50, large: 50 }),
+          paddingTop: BP({ small: 20, medium: 30, large: 50 }),
           paddingHorizontal: BP({ small: 16, medium: 20, large: 30 }),
         }}>
         <Header
@@ -47,7 +47,7 @@ const HowToChangePIN: React.FC<PropsI> = ({
         <Paragraph
           color={Colors.white80}
           customStyles={{
-            marginTop: 24,
+            marginTop: BP({ small: 0, medium: 12, large: 24 }),
             fontSize: BP({ small: 16, medium: 16, large: 20 }),
             lineHeight: BP({ small: 18, medium: 18, large: 22 }),
             alignSelf: 'flex-start',
@@ -68,9 +68,9 @@ const HowToChangePIN: React.FC<PropsI> = ({
         </Paragraph>
         <View
           style={{
-            transform: [{ scale: BP({ small: 0.75, medium: 1, large: 1 }) }],
+            transform: [{ scale: BP({ small: 0.7, medium: 1, large: 1 }) }],
             position: 'absolute',
-            bottom: BP({ small: -70, medium: -50, large: -50 }),
+            bottom: BP({ small: -80, medium: -70, large: -50 }),
           }}>
           <RecoveryInstructions />
         </View>

--- a/src/ui/deviceauth/utils/fonts.ts
+++ b/src/ui/deviceauth/utils/fonts.ts
@@ -1,9 +1,10 @@
 import { Colors } from '../colors'
+import { fontLight, fontMain, fontMedium } from '../../../styles/typography'
 
 export enum Fonts {
-  Regular = 'TTCommons-Regular',
-  Medium = 'TTCommons-Medium',
-  Light = 'TTCommons-Light',
+  Regular = fontMain,
+  Medium = fontMedium,
+  Light = fontLight,
 }
 
 export const TextStyle = {

--- a/src/ui/structure/wrapper.tsx
+++ b/src/ui/structure/wrapper.tsx
@@ -32,12 +32,13 @@ const mapDispatchToProps = (dispatch: ThunkDispatch) => ({
 
 const mapStateToAppWrapProps = (state: RootState) => state.generic.appWrapConfig
 const mapDispatchToAppWrapProps = (dispatch: ThunkDispatch) => ({
-  lockApp: () => dispatch(genericActions.lockApp())
+  lockApp: () => dispatch(genericActions.lockApp()),
 })
 
 interface Props
   extends Partial<AppWrapConfig>,
     ReturnType<typeof mapDispatchToProps> {
+  readonly customStyles?: ViewStyle
   readonly withoutSafeArea?: boolean
   readonly dark?: boolean
   readonly breathy?: boolean
@@ -140,7 +141,7 @@ const AppWrapContainer: React.FC<AppWrapProps> = props => {
 
 export const AppWrap = connect(
   mapStateToAppWrapProps,
-  mapDispatchToAppWrapProps
+  mapDispatchToAppWrapProps,
 )(AppWrapContainer)
 
 export const Wrapper = React.memo(
@@ -164,12 +165,15 @@ export const Wrapper = React.memo(
       centered,
       overlay,
       heightless,
+      withoutStatusBar,
+      customStyles,
     } = props
 
     const extraStyle: StyleProp<ViewStyle> = {
       // Note: StatusBar.currentHeight is not available on iOS
       paddingTop: withoutSafeArea ? 0 : StatusBar.currentHeight,
     }
+    if (withoutStatusBar) extraStyle.paddingTop = 0
     if (dark) extraStyle.backgroundColor = backgroundDarkMain
     if (breathy) extraStyle.justifyContent = 'space-around'
     if (centered) extraStyle.alignItems = 'center'
@@ -183,6 +187,9 @@ export const Wrapper = React.memo(
       extraStyle.zIndex = 12 // good number
       extraStyle.backgroundColor = 'transparent'
     }
+
+    //NOTE: <Wrapper> now cares a bit bout yo style.
+    if (customStyles) Object.assign(extraStyle, customStyles)
 
     // @ts-ignore
     if (__DEV__ && props.style) {


### PR DESCRIPTION
This PR introduces the `customStyles` prop for the `Wrapper`. [#1635 ](https://github.com/jolocom/smartwallet-app/pull/1635) branch builds on this one and renames the prop to `styles`. 