### PR TITLE
Changed background color according to designs

### DIFF
--- a/src/reducers/generic/index.ts
+++ b/src/reducers/generic/index.ts
@@ -12,11 +12,13 @@ export interface AppWrapConfig {
   readonly withoutStatusBar: boolean
   readonly loading: boolean
   readonly dark: boolean
+  readonly secondaryDark: boolean
 }
 const initialAppWrapAttrs: AppWrapConfig = {
   loading: false,
   withoutStatusBar: false,
   dark: false,
+  secondaryDark: false,
 }
 
 export const isAppWrapConfigAttr = (key: string) => initialAppWrapAttrs[key] !== undefined

--- a/src/ui/deviceauth/ChangePIN.tsx
+++ b/src/ui/deviceauth/ChangePIN.tsx
@@ -49,7 +49,7 @@ const ChangePin: React.FC<PropsI> = ({ navigation }) => {
   }
 
   return (
-    <Wrapper dark>
+    <Wrapper secondaryDark>
       <NavigationSection
         isBackButton={false}
         onNavigation={() => navigation.goBack()}

--- a/src/ui/deviceauth/HowToChangePIN.tsx
+++ b/src/ui/deviceauth/HowToChangePIN.tsx
@@ -48,8 +48,8 @@ const HowToChangePIN: React.FC<PropsI> = ({
           color={Colors.white80}
           customStyles={{
             marginTop: BP({ small: 0, medium: 12, large: 24 }),
-            fontSize: BP({ small: 16, medium: 16, large: 20 }),
-            lineHeight: BP({ small: 18, medium: 18, large: 22 }),
+            fontSize: BP({ small: 16, medium: 18, large: 20 }),
+            lineHeight: BP({ small: 18, medium: 20, large: 22 }),
             alignSelf: 'flex-start',
             textAlign: 'left',
           }}>
@@ -58,8 +58,8 @@ const HowToChangePIN: React.FC<PropsI> = ({
         <Paragraph
           color={Colors.white80}
           customStyles={{
-            fontSize: BP({ small: 16, medium: 16, large: 20 }),
-            lineHeight: BP({ small: 18, medium: 18, large: 22 }),
+            fontSize: BP({ small: 16, medium: 18, large: 20 }),
+            lineHeight: BP({ small: 18, medium: 20, large: 22 }),
             alignSelf: 'flex-start',
             textAlign: 'left',
             marginTop: 18,
@@ -70,7 +70,7 @@ const HowToChangePIN: React.FC<PropsI> = ({
           style={{
             transform: [{ scale: BP({ small: 0.7, medium: 1, large: 1 }) }],
             position: 'absolute',
-            bottom: BP({ small: -80, medium: -70, large: -50 }),
+            bottom: BP({ small: -80, medium: -80, large: -50 }),
           }}>
           <RecoveryInstructions />
         </View>

--- a/src/ui/deviceauth/HowToChangePIN.tsx
+++ b/src/ui/deviceauth/HowToChangePIN.tsx
@@ -4,7 +4,6 @@ import { connect } from 'react-redux'
 
 import I18n from 'src/locales/i18n'
 
-import ScreenContainer from './components/ScreenContainer'
 import Header from './components/Header'
 import Paragraph, { ParagraphSizes } from './components/Paragraph'
 import Btn, { BtnTypes } from './components/Btn'
@@ -16,6 +15,8 @@ import { BP } from '../../styles/breakpoints'
 import { navigationActions } from 'src/actions'
 import { routeList } from 'src/routeList'
 import RecoveryInstructions from 'src/resources/svg/ForgotPINInstructions'
+import { Wrapper } from '../structure'
+import PasscodeWrapper from './components/PasscodeWrapper'
 
 interface PropsI {
   handleGoBack: () => void
@@ -26,70 +27,74 @@ const HowToChangePIN: React.FC<PropsI> = ({
   handleAccessRestore,
 }) => {
   return (
-    <ScreenContainer
+    <Wrapper
       customStyles={{
         backgroundColor: Colors.black,
-        justifyContent: 'flex-start',
-        paddingTop: BP({ small: 30, medium: 50, large: 50 }),
-        paddingHorizontal: 20,
       }}>
-      <Header
-        color={Colors.white90}
+      <PasscodeWrapper
         customStyles={{
-          fontSize: BP({ small: 24, medium: 28, large: 28 }),
-          alignSelf: 'flex-start',
+          paddingTop: BP({ small: 30, medium: 50, large: 50 }),
+          paddingHorizontal: BP({ small: 16, medium: 20, large: 30 }),
         }}>
-        {I18n.t(strings.HOW_TO_CHANGE_PIN)}
-      </Header>
-      <Paragraph
-        color={Colors.white80}
-        customStyles={{
-          alignSelf: 'flex-start',
-          textAlign: 'left',
-          lineHeight: 17,
-        }}>
-        {I18n.t(strings.WE_ARE_SORRY_THAT_YOU_FORGOT)}
-      </Paragraph>
-      <Paragraph
-        color={Colors.white80}
-        customStyles={{
-          alignSelf: 'flex-start',
-          textAlign: 'left',
-          lineHeight: 17,
-          marginTop: 10,
-        }}>
-        {I18n.t(strings.YOU_CAN_CHANGE_PIN)}
-      </Paragraph>
-      <View
-        style={{
-          transform: [{ scale: BP({ small: 0.75, medium: 1, large: 1 }) }],
-          position: 'absolute',
-          bottom: BP({ small: -70, medium: -50, large: -50 }),
-        }}>
-        <RecoveryInstructions />
-      </View>
-      <AbsoluteBottom customStyles={{ alignSelf: 'center', bottom: 0 }}>
-        <Btn onPress={handleAccessRestore}>
-          {I18n.t(strings.RESTORE_ACCESS)}
-        </Btn>
-        <Paragraph
-          size={ParagraphSizes.micro}
-          color={Colors.white70}
+        <Header
+          color={Colors.white90}
           customStyles={{
-            paddingHorizontal: BP({
-              small: 10,
-              medium: 25,
-              large: 25,
-            }),
-            lineHeight: 15,
+            fontSize: BP({ small: 24, medium: 28, large: 28 }),
+            alignSelf: 'flex-start',
           }}>
-          {I18n.t(strings.STORING_NO_AFFECT_DATA)}
+          {I18n.t(strings.HOW_TO_CHANGE_PIN)}
+        </Header>
+        <Paragraph
+          color={Colors.white80}
+          customStyles={{
+            marginTop: 24,
+            alignSelf: 'flex-start',
+            textAlign: 'left',
+            lineHeight: 17,
+          }}>
+          {I18n.t(strings.WE_ARE_SORRY_THAT_YOU_FORGOT)}
         </Paragraph>
-        <Btn onPress={handleGoBack} type={BtnTypes.secondary}>
-          {I18n.t(strings.CANCEL)}
-        </Btn>
-      </AbsoluteBottom>
-    </ScreenContainer>
+        <Paragraph
+          color={Colors.white80}
+          customStyles={{
+            alignSelf: 'flex-start',
+            textAlign: 'left',
+            lineHeight: 17,
+            marginTop: 17,
+          }}>
+          {I18n.t(strings.YOU_CAN_CHANGE_PIN)}
+        </Paragraph>
+        <View
+          style={{
+            transform: [{ scale: BP({ small: 0.75, medium: 1, large: 1 }) }],
+            position: 'absolute',
+            bottom: BP({ small: -70, medium: -50, large: -50 }),
+          }}>
+          <RecoveryInstructions />
+        </View>
+        <AbsoluteBottom customStyles={{ alignSelf: 'center', bottom: 0 }}>
+          <Btn onPress={handleAccessRestore}>
+            {I18n.t(strings.RESTORE_ACCESS)}
+          </Btn>
+          <Paragraph
+            size={ParagraphSizes.micro}
+            color={Colors.white70}
+            customStyles={{
+              paddingHorizontal: BP({
+                small: 10,
+                medium: 25,
+                large: 25,
+              }),
+              lineHeight: 15,
+            }}>
+            {I18n.t(strings.STORING_NO_AFFECT_DATA)}
+          </Paragraph>
+          <Btn onPress={handleGoBack} type={BtnTypes.secondary}>
+            {I18n.t(strings.CANCEL)}
+          </Btn>
+        </AbsoluteBottom>
+      </PasscodeWrapper>
+    </Wrapper>
   )
 }
 

--- a/src/ui/deviceauth/HowToChangePIN.tsx
+++ b/src/ui/deviceauth/HowToChangePIN.tsx
@@ -48,19 +48,21 @@ const HowToChangePIN: React.FC<PropsI> = ({
           color={Colors.white80}
           customStyles={{
             marginTop: 24,
+            fontSize: BP({ small: 16, medium: 16, large: 20 }),
+            lineHeight: BP({ small: 18, medium: 18, large: 22 }),
             alignSelf: 'flex-start',
             textAlign: 'left',
-            lineHeight: 17,
           }}>
           {I18n.t(strings.WE_ARE_SORRY_THAT_YOU_FORGOT)}
         </Paragraph>
         <Paragraph
           color={Colors.white80}
           customStyles={{
+            fontSize: BP({ small: 16, medium: 16, large: 20 }),
+            lineHeight: BP({ small: 18, medium: 18, large: 22 }),
             alignSelf: 'flex-start',
             textAlign: 'left',
-            lineHeight: 17,
-            marginTop: 17,
+            marginTop: 18,
           }}>
           {I18n.t(strings.YOU_CAN_CHANGE_PIN)}
         </Paragraph>

--- a/src/ui/deviceauth/HowToChangePIN.tsx
+++ b/src/ui/deviceauth/HowToChangePIN.tsx
@@ -28,7 +28,7 @@ const HowToChangePIN: React.FC<PropsI> = ({
 }) => {
   return (
     <Wrapper
-      customStyles={{
+      style={{
         backgroundColor: Colors.black,
       }}>
       <PasscodeWrapper

--- a/src/ui/deviceauth/HowToChangePIN.tsx
+++ b/src/ui/deviceauth/HowToChangePIN.tsx
@@ -33,7 +33,7 @@ const HowToChangePIN: React.FC<PropsI> = ({
       }}>
       <PasscodeWrapper
         customStyles={{
-          paddingTop: BP({ small: 30, medium: 50, large: 50 }),
+          paddingTop: BP({ small: 20, medium: 30, large: 50 }),
           paddingHorizontal: BP({ small: 16, medium: 20, large: 30 }),
         }}>
         <Header
@@ -47,7 +47,7 @@ const HowToChangePIN: React.FC<PropsI> = ({
         <Paragraph
           color={Colors.white80}
           customStyles={{
-            marginTop: 24,
+            marginTop: BP({ small: 0, medium: 12, large: 24 }),
             fontSize: BP({ small: 16, medium: 16, large: 20 }),
             lineHeight: BP({ small: 18, medium: 18, large: 22 }),
             alignSelf: 'flex-start',
@@ -68,9 +68,9 @@ const HowToChangePIN: React.FC<PropsI> = ({
         </Paragraph>
         <View
           style={{
-            transform: [{ scale: BP({ small: 0.75, medium: 1, large: 1 }) }],
+            transform: [{ scale: BP({ small: 0.7, medium: 1, large: 1 }) }],
             position: 'absolute',
-            bottom: BP({ small: -70, medium: -50, large: -50 }),
+            bottom: BP({ small: -80, medium: -70, large: -50 }),
           }}>
           <RecoveryInstructions />
         </View>

--- a/src/ui/deviceauth/Lock.tsx
+++ b/src/ui/deviceauth/Lock.tsx
@@ -6,7 +6,6 @@ import { NavigationInjectedProps } from 'react-navigation'
 import I18n from 'src/locales/i18n'
 
 import PasscodeInput from './PasscodeInput'
-import Header from './components/Header'
 import Btn, { BtnTypes } from './components/Btn'
 
 import strings from '../../locales/strings'
@@ -74,7 +73,7 @@ const Lock: React.FC<LockProps> = ({
   }
 
   return (
-    <Wrapper dark>
+    <Wrapper secondaryDark>
       <PasscodeWrapper>
         <PasscodeHeader>{I18n.t(strings.ENTER_YOUR_PIN)}</PasscodeHeader>
         <View style={styles.inputContainer}>

--- a/src/ui/deviceauth/RegisterPIN.tsx
+++ b/src/ui/deviceauth/RegisterPIN.tsx
@@ -6,9 +6,7 @@ import I18n from 'src/locales/i18n'
 
 import Header from './components/Header'
 import Paragraph, { ParagraphSizes } from './components/Paragraph'
-import AbsoluteBottom from './components/AbsoluteBottom'
 import Btn, { BtnTypes } from './components/Btn'
-import ScreenContainer from './components/ScreenContainer'
 import PasscodeInput from './PasscodeInput'
 import strings from '../../locales/strings'
 import { PIN_USERNAME, PIN_SERVICE } from './utils/keychainConsts'
@@ -18,7 +16,6 @@ import { Colors } from './colors'
 import { connect } from 'react-redux'
 import { ThunkDispatch } from 'src/store'
 import { genericActions } from 'src/actions'
-import useKeyboardHeight from './hooks/useKeyboardHeight'
 import { NavigationInjectedProps } from 'react-navigation'
 import useDisableBackButton from './hooks/useDisableBackButton'
 import { Wrapper } from '../structure'
@@ -41,8 +38,6 @@ const RegisterPIN: React.FC<PropsI> = ({ unlockApplication, navigation }) => {
       return navigation.isFocused()
     }, []),
   )
-
-  const { keyboardHeight } = useKeyboardHeight()
 
   const handlePasscodeSubmit = useCallback(() => {
     setIsCreating(false)
@@ -82,7 +77,7 @@ const RegisterPIN: React.FC<PropsI> = ({ unlockApplication, navigation }) => {
   }, [verifiedPasscode])
 
   return (
-    <Wrapper dark>
+    <Wrapper secondaryDark>
       <PasscodeWrapper customStyles={{ paddingTop: 38 }}>
         <View>
           <Header color={Colors.white90}>

--- a/src/ui/deviceauth/utils/fonts.ts
+++ b/src/ui/deviceauth/utils/fonts.ts
@@ -1,9 +1,10 @@
 import { Colors } from '../colors'
+import { fontLight, fontMain, fontMedium } from '../../../styles/typography'
 
 export enum Fonts {
-  Regular = 'TTCommons-Regular',
-  Medium = 'TTCommons-Medium',
-  Light = 'TTCommons-Light',
+  Regular = fontMain,
+  Medium = fontMedium,
+  Light = fontLight,
 }
 
 export const TextStyle = {

--- a/src/ui/errors/containers/errorReporting.tsx
+++ b/src/ui/errors/containers/errorReporting.tsx
@@ -78,7 +78,7 @@ const ErrorReportingContainer = (props: Props) => {
   }
 
   return (
-    <Wrapper dark>
+    <Wrapper secondaryDark>
       <NavigationSection
         onNavigation={navigateBack}
         isBackButton={isBackButton}

--- a/src/ui/structure/actionSheet.tsx
+++ b/src/ui/structure/actionSheet.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { Animated, LayoutChangeEvent, StyleSheet, View } from 'react-native'
+import { Animated, LayoutChangeEvent, StyleSheet, View, ViewStyle } from 'react-native'
 import { Colors } from '../../styles'
 import { overflowBlack } from '../../styles/colors'
 
@@ -21,10 +21,11 @@ const styles = StyleSheet.create({
 
 interface Props {
   showSlide: boolean
+  customStyles?: ViewStyle
 }
 
 export const ActionSheet: React.FC<Props> = props => {
-  const { showSlide } = props
+  const { showSlide, customStyles = {} } = props
   // NOTE: default height is 9999 to make sure the view is hidden on first render
   const [viewHeight, setViewHeight] = useState(9999)
   const [animatedValue] = useState(new Animated.Value(0))
@@ -63,6 +64,7 @@ export const ActionSheet: React.FC<Props> = props => {
     <Animated.View
       style={{
         ...styles.wrapper,
+        ...customStyles,
         transform: [{ translateY: interpolatedValue }],
       }}
       onLayout={getDimensions}

--- a/src/ui/structure/wrapper.tsx
+++ b/src/ui/structure/wrapper.tsx
@@ -22,6 +22,7 @@ import {
 import { RootState } from 'src/reducers'
 import { useAppState } from '../deviceauth/hooks/useAppState'
 import { genericActions } from 'src/actions'
+import { Colors } from '../deviceauth/colors'
 
 const mapDispatchToProps = (dispatch: ThunkDispatch) => ({
   registerProps: (props: Props) =>
@@ -41,6 +42,7 @@ interface Props
   readonly customStyles?: ViewStyle
   readonly withoutSafeArea?: boolean
   readonly dark?: boolean
+  readonly secondaryDark?: boolean
   readonly breathy?: boolean
   readonly centered?: boolean
   readonly overlay?: boolean
@@ -69,6 +71,7 @@ interface AppWrapProps
  * Wrapper props:
  * withoutSafeArea    don't pad for SafeArea
  * dark               use dark background and status bar
+ * secondaryDark      lighter background and status bar
  * breathy            justify with 'space-around', for a breathy look-n-feel
  * centered           alignItems 'center'
  * overlay            absolutely positioned transpare overlay
@@ -89,7 +92,7 @@ const styles = StyleSheet.create({
 
 let statusBarHidden = 0
 const AppWrapContainer: React.FC<AppWrapProps> = props => {
-  const { dark, loading, withoutStatusBar, lockApp } = props
+  const { dark, secondaryDark, loading, withoutStatusBar, lockApp } = props
 
   useEffect(() => {
     // TODO @mnzaki
@@ -127,7 +130,7 @@ const AppWrapContainer: React.FC<AppWrapProps> = props => {
     <>
       <StatusBar
         //hidden={statusBarHidden > 0}
-        barStyle={dark ? 'light-content' : 'dark-content'}
+        barStyle={dark || secondaryDark ? 'light-content' : 'dark-content'}
         backgroundColor={'transparent'}
         animated
         translucent
@@ -167,6 +170,7 @@ export const Wrapper = React.memo(
       heightless,
       withoutStatusBar,
       customStyles,
+      secondaryDark
     } = props
 
     const extraStyle: StyleProp<ViewStyle> = {
@@ -175,6 +179,7 @@ export const Wrapper = React.memo(
     }
     if (withoutStatusBar) extraStyle.paddingTop = 0
     if (dark) extraStyle.backgroundColor = backgroundDarkMain
+    if (secondaryDark) extraStyle.backgroundColor = Colors.mainBlack
     if (breathy) extraStyle.justifyContent = 'space-around'
     if (centered) extraStyle.alignItems = 'center'
     if (heightless) {

--- a/src/ui/structure/wrapper.tsx
+++ b/src/ui/structure/wrapper.tsx
@@ -39,7 +39,7 @@ const mapDispatchToAppWrapProps = (dispatch: ThunkDispatch) => ({
 interface Props
   extends Partial<AppWrapConfig>,
     ReturnType<typeof mapDispatchToProps> {
-  readonly customStyles?: ViewStyle
+  readonly style?: ViewStyle
   readonly withoutSafeArea?: boolean
   readonly dark?: boolean
   readonly secondaryDark?: boolean
@@ -76,6 +76,7 @@ interface AppWrapProps
  * centered           alignItems 'center'
  * overlay            absolutely positioned transpare overlay
  * heightless         set height to 0 instead of default 100%
+ * style              custom styles for the wrapping view
  * testID             ID/label for use in tests
  */
 
@@ -86,7 +87,6 @@ const styles = StyleSheet.create({
     height: '100%',
     width: '100%',
     backgroundColor: backgroundLightMain,
-    //...debug
   },
 })
 
@@ -169,8 +169,8 @@ export const Wrapper = React.memo(
       overlay,
       heightless,
       withoutStatusBar,
-      customStyles,
-      secondaryDark
+      style,
+      secondaryDark,
     } = props
 
     const extraStyle: StyleProp<ViewStyle> = {
@@ -193,16 +193,7 @@ export const Wrapper = React.memo(
       extraStyle.backgroundColor = 'transparent'
     }
 
-    //NOTE: <Wrapper> now cares a bit bout yo style.
-    if (customStyles) Object.assign(extraStyle, customStyles)
-
-    // @ts-ignore
-    if (__DEV__ && props.style) {
-      throw new Error(
-        '<Wrapper> dont care bout yo style. ' +
-          'Look at src/ui/structure/wrapper.tsx',
-      )
-    }
+    if (style) Object.assign(extraStyle, style)
 
     return (
       <>

--- a/src/ui/structure/wrapper.tsx
+++ b/src/ui/structure/wrapper.tsx
@@ -32,12 +32,13 @@ const mapDispatchToProps = (dispatch: ThunkDispatch) => ({
 
 const mapStateToAppWrapProps = (state: RootState) => state.generic.appWrapConfig
 const mapDispatchToAppWrapProps = (dispatch: ThunkDispatch) => ({
-  lockApp: () => dispatch(genericActions.lockApp())
+  lockApp: () => dispatch(genericActions.lockApp()),
 })
 
 interface Props
   extends Partial<AppWrapConfig>,
     ReturnType<typeof mapDispatchToProps> {
+  readonly customStyles?: ViewStyle
   readonly withoutSafeArea?: boolean
   readonly dark?: boolean
   readonly breathy?: boolean
@@ -140,7 +141,7 @@ const AppWrapContainer: React.FC<AppWrapProps> = props => {
 
 export const AppWrap = connect(
   mapStateToAppWrapProps,
-  mapDispatchToAppWrapProps
+  mapDispatchToAppWrapProps,
 )(AppWrapContainer)
 
 export const Wrapper = React.memo(
@@ -164,12 +165,15 @@ export const Wrapper = React.memo(
       centered,
       overlay,
       heightless,
+      withoutStatusBar,
+      customStyles,
     } = props
 
     const extraStyle: StyleProp<ViewStyle> = {
       // Note: StatusBar.currentHeight is not available on iOS
       paddingTop: withoutSafeArea ? 0 : StatusBar.currentHeight,
     }
+    if (withoutStatusBar) extraStyle.paddingTop = 0
     if (dark) extraStyle.backgroundColor = backgroundDarkMain
     if (breathy) extraStyle.justifyContent = 'space-around'
     if (centered) extraStyle.alignItems = 'center'
@@ -183,6 +187,9 @@ export const Wrapper = React.memo(
       extraStyle.zIndex = 12 // good number
       extraStyle.backgroundColor = 'transparent'
     }
+
+    //NOTE: <Wrapper> now cares a bit bout yo style.
+    if (customStyles) Object.assign(extraStyle, customStyles)
 
     // @ts-ignore
     if (__DEV__ && props.style) {

--- a/src/ui/termsAndPrivacy/legalTextComponent.tsx
+++ b/src/ui/termsAndPrivacy/legalTextComponent.tsx
@@ -42,7 +42,7 @@ export const LegalTextComponent: React.FC<Props> = ({
   }
 
   return (
-    <Wrapper dark>
+    <Wrapper secondaryDark>
       <NavigationSection onNavigation={onBackPress} isBackButton={true} />
       <View style={styles.wrapper}>
         <Text style={styles.header}>{I18n.t(title)}</Text>

--- a/src/ui/termsAndPrivacy/termsOfServiceConsent.tsx
+++ b/src/ui/termsAndPrivacy/termsOfServiceConsent.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react-native'
 import { ThunkDispatch } from 'src/store'
 import { storeTermsOfService } from 'src/actions/generic'
-import { JolocomButton } from '../structure'
+import { JolocomButton, Wrapper } from '../structure'
 import { connect } from 'react-redux'
 import { NavigationScreenProp, NavigationState } from 'react-navigation'
 import { routeList } from 'src/routeList'
@@ -24,7 +24,8 @@ import { CheckmarkSmallIcon } from 'src/resources'
 import strings from 'src/locales/strings'
 import I18n from 'src/locales/i18n'
 import { BP } from 'src/styles/breakpoints'
-import ScreenContainer from 'src/ui/deviceauth/components/ScreenContainer'
+import { Colors } from '../../styles'
+import { ActionSheet } from '../structure/actionSheet'
 
 interface NavigationProps {
   nextRoute: routeList
@@ -93,8 +94,7 @@ const TermsOfServiceConsentContainer: React.FC<Props> = ({
   }
 
   return (
-    <ScreenContainer>
-      <StatusBar barStyle="light-content" />
+    <Wrapper dark customStyles={{ backgroundColor: Colors.baseBlack }}>
       <View
         style={{ paddingHorizontal: BP({ small: 20, medium: 32, large: 32 }) }}>
         <Text style={styles.title}>
@@ -124,11 +124,11 @@ const TermsOfServiceConsentContainer: React.FC<Props> = ({
                 onPress={() => setTextType(TextType.PrivacyEN)}
               />
               <ConsentTextButton
-                text={'Nutzungsbedingungen '}
+                text={'Nutzungsbedingungen'}
                 onPress={() => setTextType(TextType.TermsDE)}
               />
               <ConsentTextButton
-                text={'Datenschutzerklärung '}
+                text={'Datenschutzerklärung'}
                 onPress={() => setTextType(TextType.PrivacyDE)}
               />
             </>
@@ -140,7 +140,7 @@ const TermsOfServiceConsentContainer: React.FC<Props> = ({
           )}
         </ScrollView>
       </View>
-      <View style={styles.bottomBar}>
+      <ActionSheet showSlide={true} customStyles={styles.bottomBar}>
         <TouchableOpacity
           onPress={() => setAccepted(!accepted)}
           style={styles.acceptWrapper}>
@@ -170,8 +170,8 @@ const TermsOfServiceConsentContainer: React.FC<Props> = ({
           }}
           disabled={!accepted}
         />
-      </View>
-    </ScreenContainer>
+      </ActionSheet>
+    </Wrapper>
   )
 }
 
@@ -203,16 +203,9 @@ const styles = StyleSheet.create({
     marginBottom: BP({ small: 32, medium: 54, large: 54 }),
   },
   bottomBar: {
-    paddingVertical: 26,
-    width: '100%',
-    position: 'absolute',
-    bottom: 0,
-    backgroundColor: 'rgb(11, 3,13)',
-    alignItems: 'center',
-    justifyContent: 'space-evenly',
+    paddingTop: 26,
+    paddingBottom: 40,
     paddingHorizontal: 20,
-    borderTopLeftRadius: 22,
-    borderTopRightRadius: 22,
   },
   checkboxBase: {
     width: 28,

--- a/src/ui/termsAndPrivacy/termsOfServiceConsent.tsx
+++ b/src/ui/termsAndPrivacy/termsOfServiceConsent.tsx
@@ -5,7 +5,6 @@ import {
   View,
   StyleSheet,
   TouchableOpacity,
-  StatusBar,
 } from 'react-native'
 import { ThunkDispatch } from 'src/store'
 import { storeTermsOfService } from 'src/actions/generic'
@@ -24,7 +23,6 @@ import { CheckmarkSmallIcon } from 'src/resources'
 import strings from 'src/locales/strings'
 import I18n from 'src/locales/i18n'
 import { BP } from 'src/styles/breakpoints'
-import { Colors } from '../../styles'
 import { ActionSheet } from '../structure/actionSheet'
 
 interface NavigationProps {
@@ -94,7 +92,7 @@ const TermsOfServiceConsentContainer: React.FC<Props> = ({
   }
 
   return (
-    <Wrapper dark customStyles={{ backgroundColor: Colors.baseBlack }}>
+    <Wrapper secondaryDark>
       <View
         style={{ paddingHorizontal: BP({ small: 20, medium: 32, large: 32 }) }}>
         <Text style={styles.title}>


### PR DESCRIPTION
The `Wrapper` now accepts two additional props: `style` and `secondaryDark`. `style` is still needed b/c of the `HowToChangePin` screen, which has a semi-transparent SVG with black gradients, making it an outlier in terms of the backgroundColor. The `secondaryDark` prop is used for all the new screens that were added for this release (device auth, terms, terms consent).