### PR TITLE
Fix behavior of already seen interactions

### DIFF
--- a/src/actions/sso/authenticationRequest.ts
+++ b/src/actions/sso/authenticationRequest.ts
@@ -26,8 +26,9 @@ export const sendAuthenticationResponse = (
   const interaction = await sdk.interactionManager.getInteraction(
     interactionId,
   )
-  return interaction
-    .send(await interaction.createAuthenticationResponse())
-    .then(() => dispatch(cancelSSO))
-    .then(() => dispatch(scheduleSuccessNotification))
+  const resp = await interaction.createAuthenticationResponse()
+  await interaction.send(resp)
+  await interaction.processInteractionToken(resp)
+  await dispatch(cancelSSO)
+  return dispatch(scheduleSuccessNotification)
 }

--- a/src/actions/sso/credentialOffer.ts
+++ b/src/actions/sso/credentialOffer.ts
@@ -52,14 +52,8 @@ export const consumeCredentialReceive = (
   const response = await interaction.createCredentialOfferResponseToken(
     selectedSignedCredentialWithMetadata,
   )
-
   await interaction.processInteractionToken(response)
-
-  await interaction.send(
-    await interaction.createCredentialOfferResponseToken(
-      selectedSignedCredentialWithMetadata,
-    ),
-  )
+  await interaction.send(response)
 
   return dispatch(
     validateSelectionAndSave(

--- a/src/actions/sso/credentialRequest.ts
+++ b/src/actions/sso/credentialRequest.ts
@@ -80,12 +80,12 @@ export const sendCredentialResponse = (
     interactionId,
   )
 
-  return interaction
-    .send(
-      await interaction.createCredentialResponse(
-        selectedCredentials.map(c => c.id),
-      ),
-    )
-    .then(() => dispatch(cancelSSO))
-    .then(() => dispatch(scheduleSuccessNotification))
+  const resp = await interaction.createCredentialResponse(
+    selectedCredentials.map(c => c.id),
+  )
+  await interaction.send(resp)
+  await interaction.processInteractionToken(resp)
+
+  await dispatch(cancelSSO)
+  return dispatch(scheduleSuccessNotification)
 }

--- a/src/actions/sso/establishChannel.ts
+++ b/src/actions/sso/establishChannel.ts
@@ -1,14 +1,12 @@
 import { navigationActions } from 'src/actions'
 import { routeList } from 'src/routeList'
 import { ThunkAction } from '../../store'
-import { Interaction, FlowType, ErrorCode } from '@jolocom/sdk'
+import { Interaction, FlowType } from '@jolocom/sdk'
 import { cancelSSO, scheduleSuccessNotification } from '.'
 import { scheduleNotification } from '../notifications'
 import { createInfoNotification, createWarningNotification } from '../../lib/notifications'
 import I18n from 'src/locales/i18n'
 import strings from '../../locales/strings'
-import { showErrorScreen } from '../generic'
-import { AppError } from 'src/lib/errors'
 import { Channel } from '@jolocom/sdk/js/channels'
 
 export const consumeEstablishChannelRequest = (


### PR DESCRIPTION
If an interaction was not completed but rather cancelled and then its QR rescanned, it should be possible to complete it.

Current solution is very simple, if there's only 1 message seen then we consider the interaction not complete.
A better solution would be for the SDK to actually maintain a `finished` state for each interaction, which may be different depending on the interaction flow.

This PR also makes sure we `processInteractionToken` on the response tokens being sent, which is necessary for the SDK to save the response.